### PR TITLE
Enable etcd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ source /etc/profile.d/congo.sh
 congo list
 ```
 
+### Start goconserver with xcat
+
+Currently `xcat` and `goconserver` are integrated with `file` storage type.
+Some reference doc could be found at
+
+- [rcons](http://xcat-docs.readthedocs.io/en/latest/guides/admin-guides/manage_clusters/ppc64le/management/basic/rcons.html)
+- [gocons](http://xcat-docs.readthedocs.io/en/latest/advanced/goconserver/index.html)
+
 ## Development
 
 ### Requirement
@@ -100,7 +108,7 @@ make install
 
 Please refer to [ssl](/scripts/ssl/)
 
-### Web Interface (ongoing)
+### Web Interface
 
 Setup nodejs(9.0+) and npm(5.6.0+) toolkit at first. An example steps could be
 found at [node env](/frontend/). Then follow the steps below:

--- a/api/node.go
+++ b/api/node.go
@@ -93,7 +93,11 @@ func (api *NodeApi) put(w http.ResponseWriter, req *http.Request) {
 	nodes := make([]string, 0, 1)
 	nodes = append(nodes, vars["node"])
 	plog.InfoNode(vars["node"], fmt.Sprintf("The console state has been changed to %s.", state))
-	result := nodeManager.SetConsoleState(nodes, state)
+	result, err := nodeManager.SetConsoleState(nodes, state)
+	if err != nil {
+		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if resp, err = json.Marshal(result); err != nil {
 		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())
 		return
@@ -131,7 +135,11 @@ func (api *NodeApi) bulkPut(w http.ResponseWriter, req *http.Request) {
 	for _, v := range storNodes["nodes"] {
 		nodes = append(nodes, v.Name)
 	}
-	result := nodeManager.SetConsoleState(nodes, state)
+	result, err := nodeManager.SetConsoleState(nodes, state)
+	if err != nil {
+		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())
+		return
+	}
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if resp, err = json.Marshal(result); err != nil {
 		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())
@@ -191,7 +199,11 @@ func (api *NodeApi) bulkPost(w http.ResponseWriter, req *http.Request) {
 		plog.HandleHttp(w, req, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
-	result := nodeManager.PostNodes(nodes)
+	result, err := nodeManager.PostNodes(nodes)
+	if err != nil {
+		plog.HandleHttp(w, req, http.StatusBadRequest, err.Error())
+		return
+	}
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if resp, err = json.Marshal(result); err != nil {
 		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())
@@ -234,7 +246,11 @@ func (api *NodeApi) bulkDelete(w http.ResponseWriter, req *http.Request) {
 	for _, node := range nodes["nodes"] {
 		names = append(names, node.Name)
 	}
-	result := nodeManager.DeleteNodes(names)
+	result, err := nodeManager.DeleteNodes(names)
+	if err != nil {
+		plog.HandleHttp(w, req, http.StatusBadRequest, err.Error())
+		return
+	}
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if resp, err = json.Marshal(result); err != nil {
 		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())

--- a/benchmark/benchapi.py
+++ b/benchmark/benchapi.py
@@ -7,6 +7,9 @@ import json
 import time
 import requests
 import eventlet
+import argparse
+import traceback
+import inspect
 
 eventlet.monkey_patch(os=False)
 import futurist
@@ -28,18 +31,32 @@ def elaspe_run(desc=''):
 
 
 class APItest(object):
-    def __init__(self, count):
+    def __init__(self, url, method, count):
         self._executor = futurist.GreenThreadPoolExecutor(max_workers=1000)
+        self.url = url
+        self.method = method
         self.count = count
-        if 'consoleserver_host' in os.environ:
-            self.host = os.environ["consoleserver_host"]
+
+    def run(self):
+        if self.method == 'all':
+            for func in inspect.getmembers(self):
+                if func[0].startswith('test_'):
+                    getattr(self, func[0])()
+        elif hasattr(self, 'test_%s' % self.method):
+            getattr(self, 'test_%s' % self.method)()
         else:
-            self.host = 'http://localhost:12429'
+            print('Could not find method test_%s' % self.method)
+
+    def list(self):
+        print("Test function list:\n")
+        for func in inspect.getmembers(self):
+            if func[0].startswith('test_'):
+                print(func[0])
 
     @elaspe_run(desc="post")
     def test_post(self):
         def _test_post(data):
-            requests.post("%s/nodes" % self.host, data=json.dumps(data))
+            requests.post("%s/nodes" % self.url, data=json.dumps(data))
 
         futures = []
         for i in range(self.count):
@@ -62,12 +79,12 @@ class APItest(object):
                                'port': '22',
                                'private_key': '/Users/longcheng/.ssh/id_rsa'}}
             data['nodes'].append(item)
-        requests.post("%s/bulk/nodes" % self.host, data=json.dumps(data))
+        requests.post("%s/bulk/nodes" % self.url, data=json.dumps(data))
 
     @elaspe_run(desc="delete")
     def test_delete(self):
         def _test_delete(i):
-            requests.delete('%s/nodes/fakenode%d' % (self.host, i))
+            requests.delete('%s/nodes/fakenode%d' % (self.url, i))
 
         futures = []
         for i in range(self.count):
@@ -81,16 +98,16 @@ class APItest(object):
         for i in range(self.count):
             item = {'name': 'fakenode%d' % i}
             data['nodes'].append(item)
-        requests.delete('%s/bulk/nodes' % self.host, data=json.dumps(data))
+        requests.delete('%s/bulk/nodes' % self.url, data=json.dumps(data))
 
     @elaspe_run(desc="list")
     def test_list(self):
-        requests.get('%s/nodes' % self.host)
+        requests.get('%s/nodes' % self.url)
 
     @elaspe_run(desc="put_on")
     def test_put_on(self):
         def _test_put(i):
-            requests.delete('%s/nodes/fakenode%d?state=on' % (self.host, i))
+            requests.delete('%s/nodes/fakenode%d?state=on' % (self.url, i))
 
         futures = []
         for i in range(self.count):
@@ -104,13 +121,13 @@ class APItest(object):
         for i in range(self.count):
             item = {'name': 'fakenode%d' % i}
             data['nodes'].append(item)
-        requests.delete('%s/bulk/nodes?state=on' % self.host,
+        requests.delete('%s/bulk/nodes?state=on' % self.url,
                         data=json.dumps(data))
 
     @elaspe_run(desc="put_off")
     def test_put_off(self):
         def _test_put(i):
-            requests.delete('%s/nodes/fakenode%d?state=off' % (self.host, i))
+            requests.delete('%s/nodes/fakenode%d?state=off' % (self.url, i))
 
         futures = []
         for i in range(self.count):
@@ -124,13 +141,13 @@ class APItest(object):
         for i in range(self.count):
             item = {'name': 'fakenode%d' % i}
             data['nodes'].append(item)
-        requests.delete('%s/bulk/nodes?state=off' % self.host,
+        requests.delete('%s/bulk/nodes?state=off' % self.url,
                         data=json.dumps(data))
 
     @elaspe_run(desc="show")
     def test_show(self):
         def _test_get(i):
-            requests.get('%s/nodes/fakenode%d' % (self.host, i))
+            requests.get('%s/nodes/fakenode%d' % (self.url, i))
 
         futures = []
         for i in range(self.count):
@@ -139,34 +156,68 @@ class APItest(object):
         waiters.wait_for_all(futures, 3600)
 
 
-if __name__ == "__main__":
-    if len(sys.argv) == 3:
-        method = str(sys.argv[1])
-        count = int(sys.argv[2])
-        api = APItest(count)
+class BenchmarkAPI(object):
+    def get_base_parser(self):
+        parser = argparse.ArgumentParser(
+            prog='benchapi',
+            epilog='See "benchapi help COMMAND" '
+                   'for help on a specific command.',
+            add_help=False,
+            formatter_class=HelpFormatter,
+        )
+        parser.add_argument('-h', '--help',
+                            action='store_true',
+                            help=argparse.SUPPRESS)
+        parser.add_argument('-m', '--method',
+                            help="The rest api method, could be post, delete, "
+                                 "bulk_post, bulk_delete, all",
+                            default='all',
+                            type=str)
+        parser.add_argument('-c', '--count',
+                            help="The number of nodes in the test case",
+                            type=int,
+                            default=1)
+        parser.add_argument('--url',
+                            help="http url of goconserver master",
+                            type=str,
+                            default='http://localhost:12429')
+        parser.add_argument('-l', '--list',
+                            help="List the test functions for benchmark api",
+                            action='store_true')
+        return parser
 
-        if method == 'post':
-            api.test_post()
-        elif method == 'delete':
-            api.test_delete()
-        elif method == 'bulk_post':
-            api.test_bulk_post()
-        elif method == 'bulk_delete':
-            api.test_bulk_delete()
-        elif method == 'list':
-            api.test_list()
-        else:
-            print("Unsupport sub command %s." % method)
-    else:
-        count = 1000
-        api = APItest(count)
-        api.test_bulk_post()
-        api.test_list()
-        api.test_show()
-        api.test_put_on()
-        api.test_put_off()
-        api.test_bulk_put_on()
-        api.test_bulk_put_off()
-        api.test_bulk_delete()
-        api.test_post()
-        api.test_delete()
+    def do_help(self, args):
+        self.parser.print_help()
+
+    def main(self, argv):
+        self.parser = self.get_base_parser()
+        (options, args) = self.parser.parse_known_args(argv)
+
+        if options.help:
+            self.do_help(options)
+            return 0
+
+        api = APItest(options.url, options.method, options.count)
+        if options.list:
+            api.list()
+            return 0
+
+        api.run()
+
+
+class HelpFormatter(argparse.HelpFormatter):
+    def start_section(self, heading):
+        # Title-case the headings
+        heading = '%s%s' % (heading[0].upper(), heading[1:])
+        super(HelpFormatter, self).start_section(heading)
+
+
+if __name__ == "__main__":
+    try:
+        BenchmarkAPI().main(sys.argv[1:])
+    except KeyboardInterrupt:
+        print("... terminating benchmark testing", file=sys.stderr)
+        sys.exit(130)
+    except Exception as e:
+        print(traceback.format_exc())
+        sys.exit(1)

--- a/common/conf.go
+++ b/common/conf.go
@@ -84,6 +84,20 @@ type LoggerCfg struct {
 	UDP  []UDPCfg  `yaml:"udp"`
 }
 
+type EtcdCfg struct {
+	DailTimeout      int    `yaml:"dail_timeout"`
+	RequestTimeout   int    `yaml:"request_timeout"`
+	Endpoints        string `yaml:"endpoints"`
+	ServiceHeartbeat int64  `yaml:"service_heartbeat"`
+	Prefix           string `yaml: prefix`
+	SSLKeyFile       string `yaml:"ssl_key_file"`
+	SSLCertFile      string `yaml:"ssl_cert_file"`
+	SSLCACertFile    string `yaml:"ssl_ca_cert_file"`
+	// vhost is the name registered in etcd service, by default it is the hostname
+	Vhost   string `yaml:"vhost`
+	RpcPort string `yaml:"rpcport"`
+}
+
 type ServerConfig struct {
 	Global struct {
 		Host          string `yaml:"host"`
@@ -110,15 +124,9 @@ type ServerConfig struct {
 		ClientTimeout     int       `yaml:"client_timeout"`
 		TargetTimeout     int       `yaml:"target_timeout"`
 		ReconnectInterval int       `yaml:"reconnect_interval"`
-		RPCPort           string    `yaml:"rpcport"`
 		Loggers           LoggerCfg `yaml:"logger"`
 	}
-	Etcd struct {
-		DailTimeout     int    `yaml:"dail_timeout"`
-		RequestTimeout  int    `yaml:"request_timeout"`
-		Endpoints       string `yaml:"endpoints"`
-		ServerHeartbeat int64  `yaml:"server_heartbeat"`
-	}
+	Etcd EtcdCfg `yaml:"etcd"`
 }
 
 func InitServerConfig(confFile string) (*ServerConfig, error) {
@@ -139,12 +147,13 @@ func InitServerConfig(confFile string) (*ServerConfig, error) {
 	serverConfig.Console.ClientTimeout = 30
 	serverConfig.Console.TargetTimeout = 30
 	serverConfig.Console.ReconnectInterval = 5
-	serverConfig.Console.RPCPort = "12431" // only for async storage type
+	serverConfig.Etcd.RpcPort = "12431" // only for async storage type
 
 	serverConfig.Etcd.DailTimeout = 5
 	serverConfig.Etcd.RequestTimeout = 2
 	serverConfig.Etcd.Endpoints = "127.0.0.1:2379"
-	serverConfig.Etcd.ServerHeartbeat = 5
+	serverConfig.Etcd.ServiceHeartbeat = 30
+	serverConfig.Etcd.Prefix = "goconserver"
 	data, err := ioutil.ReadFile(confFile)
 	if err != nil {
 		return serverConfig, nil

--- a/common/errors.go
+++ b/common/errors.go
@@ -22,6 +22,7 @@ const (
 	HOST_NOT_EXIST
 	INVALID_TYPE
 	ETCD_NOT_INIT
+	ETCD_TRANSACTION_ERROR
 	SET_DEADLINE_ERROR
 	SEND_KEEPALIVE_ERROR
 	LOGGER_TYPE_ERROR
@@ -42,7 +43,7 @@ var (
 	ErrLocked           = NewErr(LOCKED, "Locked")
 	ErrUnlocked         = NewErr(UNLOCKED, "Unlocked")
 	ErrConnection       = NewErr(CONNECTION_ERROR, "Could not connect")
-	ErrAlreadyExist     = NewErr(ALREADY_EXIST, "Already exit")
+	ErrAlreadyExist     = NewErr(ALREADY_EXIST, "Already exist")
 	ErrOutOfQuota       = NewErr(OUTOF_QUATA, "Out of quota")
 	ErrTimeout          = NewErr(TIMEOUT, "Timeout")
 	ErrLoggerType       = NewErr(LOGGER_TYPE_ERROR, "Invalid logger type")
@@ -51,10 +52,11 @@ var (
 	ErrNotTerminal = NewErr(NOT_TERMINAL, "Not terminal")
 	ErrInvalidType = NewErr(INVALID_TYPE, "Invalid type")
 	// ssh
-	ErrSetDeadline   = NewErr(SET_DEADLINE_ERROR, "failed to set deadline")
-	ErrSendKeepalive = NewErr(SEND_KEEPALIVE_ERROR, "failed to send keep alive")
+	ErrSetDeadline   = NewErr(SET_DEADLINE_ERROR, "Failed to set deadline")
+	ErrSendKeepalive = NewErr(SEND_KEEPALIVE_ERROR, "Failed to send keep alive")
 	// etcd
-	ErrETCDNotInit = NewErr(ETCD_NOT_INIT, "Etcd is not initialized")
+	ErrEtcdUnInit      = NewErr(ETCD_NOT_INIT, "Etcd is not initialized")
+	ErrETCDTransaction = NewErr(ETCD_TRANSACTION_ERROR, "Failed to submit etcd transaction")
 )
 
 func NewErr(code int, text string) *GoConsError {

--- a/common/utils.go
+++ b/common/utils.go
@@ -21,10 +21,7 @@ const (
 	TYPE_SHARE_LOCK
 	TYPE_EXCLUDE_LOCK
 
-	SLEEP_TICK    = 100 // millisecond
-	ACTION_DELETE = 1
-	ACTION_PUT    = 0
-	ACTION_NIL    = -1
+	SLEEP_TICK = 100 // millisecond
 
 	Maxint32 = 1<<31 - 1
 

--- a/console/proto.go
+++ b/console/proto.go
@@ -1,0 +1,188 @@
+package console
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/xcat2/goconserver/common"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	ACTION_SESSION_ERROR    = 0
+	ACTION_SESSION_START    = 1
+	ACTION_SESSION_DROP     = 2
+	ACTION_SESSION_REDIRECT = 3
+	ACTION_SESSION_OK       = 4
+	ACTION_SESSION_RETRY    = 5
+)
+
+type ProtoMessage struct {
+	Action      int    `json:"action"`
+	Node        string `json:"node,omitempty"`
+	Msg         string `json:"msg,omitempty"`
+	Host        string `json:"host,omitempty"`
+	ConsolePort string `json:"console_port,omitempty"`
+	ApiPort     string `json:"api_port,omitempty"`
+}
+
+func clientHandshake(conn net.Conn, node string) (*ProtoMessage, error) {
+	m := &ProtoMessage{Action: ACTION_SESSION_START, Node: node}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	consoleTimeout := time.Duration(clientConfig.ConsoleTimeout)
+	err = common.Network.SendByteWithLengthTimeout(conn, b, consoleTimeout)
+	if err != nil {
+		return nil, err
+	}
+	n, err := common.Network.ReceiveIntTimeout(conn, consoleTimeout)
+	if err != nil {
+		return nil, err
+	}
+	b, err = common.Network.ReceiveBytesTimeout(conn, n, consoleTimeout)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func sendProtoMessage(conn net.Conn, msg string, action int, timeout time.Duration) error {
+	m := new(ProtoMessage)
+	m.Msg = msg
+	m.Action = action
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	err = common.Network.SendByteWithLengthTimeout(conn.(net.Conn), b, timeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func initConsoleSessionClient(node string, host string, consolePort string) (*ConsoleClient, net.Conn, error) {
+	client := NewConsoleClient(host, consolePort)
+	conn, err := client.Connect()
+	if err != nil {
+		return nil, nil, err
+	}
+	m, err := clientHandshake(conn, node)
+	if err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
+	switch m.Action {
+	case ACTION_SESSION_DROP:
+		return nil, nil, errors.New(m.Msg)
+	case ACTION_SESSION_REDIRECT:
+		conn.Close()
+		return initConsoleSessionClient(node, m.Host, m.ConsolePort)
+	case ACTION_SESSION_OK:
+		return client, conn, nil
+	case ACTION_SESSION_RETRY:
+		conn.Close()
+		return client, nil, nil
+	}
+	return client, conn, nil
+}
+
+func redirect(conn net.Conn, node string) error {
+	var err error
+	nodeWithHost, err := nodeManager.stor.ListNodeWithHost()
+	if err != nil {
+		plog.ErrorNode(node, err)
+		return err
+	}
+	clientTimeout := time.Duration(serverConfig.Console.ClientTimeout)
+	if _, ok := nodeWithHost[node]; !ok {
+		plog.ErrorNode(node, "Could not find this node.")
+		err = sendProtoMessage(conn, common.ErrNodeNotExist.Error(), ACTION_SESSION_DROP, clientTimeout)
+		if err != nil {
+			plog.ErrorNode(node, err)
+		}
+		return common.ErrNodeNotExist
+	}
+	host := nodeWithHost[node]
+	endpoint, err := nodeManager.stor.GetEndpoint(host)
+	if err != nil {
+		plog.ErrorNode(node, err)
+		return err
+	}
+	msg := ProtoMessage{Action: ACTION_SESSION_REDIRECT, Host: endpoint.Host, ConsolePort: endpoint.ConsolePort, ApiPort: endpoint.ApiPort}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		plog.ErrorNode(node, err)
+		return err
+	}
+	err = common.Network.SendByteWithLengthTimeout(conn, b, clientTimeout)
+	if err != nil {
+		plog.ErrorNode(node, err)
+		return err
+	}
+	plog.InfoNode(node, fmt.Sprintf("Redirect the session to %s", host))
+	return nil
+}
+
+func serverHandshake(conn net.Conn) (*Node, error) {
+	var name string
+	var m *ProtoMessage
+	var node *Node
+	var ok bool
+	clientTimeout := time.Duration(serverConfig.Console.ClientTimeout)
+	n, err := common.Network.ReceiveIntTimeout(conn, clientTimeout)
+	if err != nil {
+		conn.Close()
+		plog.Error(err)
+		return nil, err
+	}
+	b, err := common.Network.ReceiveBytesTimeout(conn, n, clientTimeout)
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	plog.Debug(fmt.Sprintf("Receive connection from client: %s", string(b)))
+	if err := json.Unmarshal(b, &m); err != nil {
+		tempErr := err
+		plog.Error(err)
+		err = sendProtoMessage(conn, err.Error(), ACTION_SESSION_ERROR, clientTimeout)
+		if err != nil {
+			plog.ErrorNode(name, err)
+			return nil, err
+		}
+		conn.Close()
+		return nil, tempErr
+	}
+	if m.Action != ACTION_SESSION_START || m.Node == "" {
+		return nil, common.ErrConnection
+	}
+	name = m.Node
+	nodeManager.RWlock.RLock()
+	if node, ok = nodeManager.Nodes[name]; !ok {
+		nodeManager.RWlock.RUnlock()
+		if !nodeManager.stor.SupportWatcher() {
+			defer conn.Close()
+			plog.ErrorNode(name, "Could not find this node.")
+			err = sendProtoMessage(conn, common.ErrNodeNotExist.Error(), ACTION_SESSION_DROP, clientTimeout)
+			if err != nil {
+				plog.ErrorNode(name, err)
+			}
+			return nil, common.ErrNodeNotExist
+		}
+		err = redirect(conn, name)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+	nodeManager.RWlock.RUnlock()
+	return node, nil
+}

--- a/etc/goconserver/server.conf
+++ b/etc/goconserver/server.conf
@@ -82,8 +82,6 @@ console:
   client_timeout: 30
   # retry interval in second if console could not be connected.
   reconnect_interval: 10
-  # [experimental] port for grpc server to support goconserver cluster, only available if storage_type is set to etcd.
-  rpcport: 12431
 
 # below is experimental option for etcd storage
 etcd:
@@ -93,3 +91,22 @@ etcd:
   endpoints: 127.0.0.1:2379
   # if timeout, the server host will be unregistered from cluster
   server_heartbeat: 5
+  # the prefix to all keys passed to storage.Interface methods
+  prefix: goconserver
+
+  # port for grpc server to support goconserver cluster, only available if storage_type is set to etcd.
+  rpcport: 12431
+
+  # the host name registered in the etcd service with business purpose
+  # it could be used for HA purpose
+
+  # vhost:
+
+  # ssl/tsl key file for etcd
+  # ssl_key_file: /etc/goconserver/cert/server-key.pem
+
+  # ssl/tsl cert file for etcd
+  # ssl_cert_file: /etc/goconserver/cert/server-cert.pem
+
+  # ssl/tsl ca cert file for etcd
+  # ssl_ca_cert_file: /etc/goconserver/cert/ca.pem

--- a/goconserver.go
+++ b/goconserver.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"github.com/gorilla/mux"
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/xcat2/goconserver/api"
 	"github.com/xcat2/goconserver/common"
 	"io/ioutil"
@@ -16,7 +16,6 @@ import (
 )
 
 var (
-	ServerCmd *cobra.Command
 	confFile  string
 	showVer   bool
 	help      bool
@@ -27,13 +26,9 @@ var (
 )
 
 func init() {
-	ServerCmd = &cobra.Command{
-		Use:   "goconserver",
-		Short: "This is goconserver damon service",
-		Long:  `goconserver daemon service`}
-	ServerCmd.Flags().StringVarP(&confFile, "config-file", "c", "/etc/goconserver/server.conf", "Specify the configuration file for goconserver daemon.")
-	ServerCmd.Flags().BoolVarP(&showVer, "version", "v", false, "Show the version of goconserver.")
-	ServerCmd.Flags().BoolVarP(&help, "help", "h", false, "Show the help message of goconserver.")
+	pflag.StringVarP(&confFile, "config-file", "c", "/etc/goconserver/server.conf", "Specify the configuration file for goconserver daemon.")
+	pflag.BoolVarP(&showVer, "version", "v", false, "Show version of goconserver.")
+	pflag.BoolVarP(&help, "help", "h", false, "Show help message of goconserver.")
 }
 
 func loadTlsConfig(serverConfig *common.ServerConfig) *tls.Config {
@@ -54,9 +49,7 @@ func loadTlsConfig(serverConfig *common.ServerConfig) *tls.Config {
 }
 
 func main() {
-	if err := ServerCmd.Execute(); err != nil {
-		panic(err)
-	}
+	pflag.Parse()
 	if showVer {
 		fmt.Printf("Version: %s, BuildTime: %s Commit: %s\n", Version, BuildTime, Commit)
 		os.Exit(0)

--- a/storage/dispatcher.go
+++ b/storage/dispatcher.go
@@ -1,0 +1,139 @@
+package storage
+
+import (
+	"github.com/xcat2/goconserver/common"
+)
+
+type Dispatcher struct {
+	stor StorInterface
+}
+
+func newDispatcher(stor StorInterface) *Dispatcher {
+	return &Dispatcher{stor: stor}
+}
+
+func (self *Dispatcher) PeekPutHost(node *Node) (string, error) {
+	if node.Labels != nil {
+		if host, ok := node.Labels["host"]; ok {
+			return host, nil
+		}
+	}
+	m, err := self.stor.GetNodeCountEachHost()
+	if err != nil {
+		return "", err
+	}
+	host := self.getMinHost(m)
+	return host, nil
+}
+
+/* peek hosts for a collection of nodes, return map(node->host) */
+func (self *Dispatcher) PeekPutHostMap(storNodes []Node) (map[*Node]string, error) {
+	alreadyMap, err := self.stor.ListNodeWithHost()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[*Node]string)
+	waitCount := 0
+	for i := 0; i < len(storNodes); i++ {
+		if _, exist := alreadyMap[storNodes[i].Name]; exist {
+			plog.WarningNode(storNodes[i].Name, common.ErrAlreadyExist)
+			continue
+		}
+		if storNodes[i].Labels != nil {
+			if host, ok := storNodes[i].Labels["host"]; ok {
+				m[&storNodes[i]] = host
+			}
+		}
+		waitCount++
+	}
+	if len(storNodes) == len(m) {
+		return m, nil
+	}
+	counts, err := self.stor.GetNodeCountEachHost() // map(host->count)
+	if err != nil {
+		return nil, err
+	}
+	if len(counts) == 0 {
+		return nil, common.ErrHostNotFound
+	}
+	for _, host := range m {
+		counts[host]++
+	}
+	sum := 0
+	i := 0
+	hosts := make([]string, len(counts))
+	for host, count := range counts {
+		sum += count
+		hosts[i] = host
+		i++
+	}
+	k := 0
+	perHostCount := (sum + waitCount) / len(counts)
+	for i = 0; i < len(storNodes); i++ {
+		if _, exist := alreadyMap[storNodes[i].Name]; exist {
+			continue
+		}
+		if _, exist := m[&storNodes[i]]; exist {
+			continue
+		}
+		if counts[hosts[k]] >= perHostCount && k < len(counts)-1 {
+			k++
+		}
+		m[&storNodes[i]] = hosts[k]
+		counts[hosts[k]]++
+	}
+	if len(m) == 0 {
+		return nil, common.ErrAlreadyExist
+	}
+	return m, nil
+}
+
+func (self *Dispatcher) PeekDelHost(node string) (string, error) {
+	var host string
+	var exist bool
+	m, err := self.stor.ListNodeWithHost()
+	if err != nil {
+		return "", err
+	}
+	if host, exist = m[node]; !exist {
+		plog.ErrorNode(node, common.ErrNotExist)
+		return "", common.ErrNotExist
+	}
+	return host, nil
+}
+
+func (self *Dispatcher) PeekDelHostMap(nodes []string) (map[string]string, error) { // node name->host
+	var host string
+	var exist bool
+	m, err := self.stor.ListNodeWithHost()
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]string)
+	for _, node := range nodes {
+		if host, exist = m[node]; !exist {
+			plog.WarningNode(node, common.ErrNotExist)
+			continue
+		}
+		ret[node] = host
+	}
+	if len(ret) == 0 {
+		return nil, common.ErrNodeNotExist
+	}
+	return ret, nil
+}
+
+func (self *Dispatcher) getMinHost(hostsCount map[string]int) string {
+	minHost := ""
+	minCount := common.Maxint32
+	for k, v := range hostsCount {
+		if v == -1 {
+			continue
+		}
+		minCount = common.If(v < minCount, v, minCount).(int)
+		if v == minCount {
+			minHost = k
+		}
+	}
+	return minHost
+}

--- a/storage/etcd.go
+++ b/storage/etcd.go
@@ -1,322 +1,316 @@
 package storage
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/xcat2/goconserver/common"
+	"github.com/xcat2/goconserver/storage/etcd"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 )
 
 const (
-	STORAGE_ETCD = "etcd"
+	STORAGE_ETCD    = "etcd"
+	LOCK_PREFIX     = "lock"
+	NODE_PREFIX     = "node"
+	ENDPOINT_PREFIX = "endpoint"
 )
 
 func init() {
 	STORAGE_INIT_MAP[STORAGE_ETCD] = newEtcdStorage
 }
 
+func EtcdKeyJoin(elems ...string) string {
+	paths := make([]string, 1, len(elems)+1)
+	paths[0] = "/" + serverConfig.Etcd.Prefix
+	paths = append(paths, elems...)
+	for i, e := range paths {
+		if e != "" {
+			return strings.Join(paths[i:], "/")
+		}
+	}
+	return ""
+}
+
 type EtcdStorage struct {
 	*Storage
-	endpoints      []string
-	dialTimeout    time.Duration
-	requestTimeout time.Duration
-	host           string
+	client *etcd.EtcdClient
+	host   string
+	// vhost is for the business service, host is the real hostname
+	vhost string
 }
 
 func newEtcdStorage() StorInterface {
 	var err error
+	var hostname string
 	stor := new(Storage)
 	stor.async = true
 	stor.Nodes = make(map[string]*Node)
 	etcdStor := new(EtcdStorage)
 	etcdStor.Storage = stor
-	etcdStor.endpoints = strings.Split(serverConfig.Etcd.Endpoints, " ")
-	etcdStor.dialTimeout = time.Duration(serverConfig.Etcd.DailTimeout) * time.Second
-	etcdStor.requestTimeout = time.Duration(serverConfig.Etcd.RequestTimeout) * time.Second
-	hostname, err := os.Hostname()
+	hostname, err = os.Hostname()
 	if err != nil {
 		panic(err)
 	}
-	etcdStor.host = hostname
-	err = etcdStor.register()
+	etcdStor.vhost = serverConfig.Etcd.Vhost
+	if etcdStor.vhost == "" {
+		etcdStor.vhost = hostname
+	}
+	etcdStor.host = serverConfig.Global.Host
+	if etcdStor.host == "" {
+		etcdStor.host = hostname
+	}
+	// As client is used to send keepalive request, the client would not be closed
+	etcdStor.client, err = etcd.NewEtcdClient(&serverConfig.Etcd)
 	if err != nil {
 		panic(err)
 	}
+	ready := make(chan struct{})
+	go etcdStor.keepalive(ready)
+	<-ready
 	return etcdStor
 }
 
-func (self *EtcdStorage) register() error {
-	cli, err := self.getClient()
+func (self *EtcdStorage) keepalive(ready chan<- struct{}) {
+	config := NewEndpointConfig(serverConfig.API.Port, serverConfig.Etcd.RpcPort, serverConfig.Console.Port, self.host)
+	b, err := config.ToByte()
 	if err != nil {
-		return err
+		panic(err)
 	}
-	defer cli.Close()
-	lease := clientv3.NewLease(cli)
-	resp, err := lease.Grant(context.TODO(), serverConfig.Etcd.ServerHeartbeat)
-	if err != nil {
-		plog.Error(fmt.Sprintf("Could not request lease from etcd, error: %s", err))
-		return err
-	}
-	key := fmt.Sprintf("/goconserver/hosts/%s", self.host)
-	_, err = cli.Put(context.TODO(), key, self.host, clientv3.WithLease(resp.ID))
-	if err != nil {
-		plog.Error(fmt.Sprintf("Could not update host on etcd, error: %s", err))
-		return err
-	}
-	go func() {
-		t := serverConfig.Etcd.ServerHeartbeat - 2
-		if t <= 0 {
-			t = 1
+	for {
+		err := self.client.RegisterAndKeepalive(EtcdKeyJoin(LOCK_PREFIX, self.vhost), EtcdKeyJoin(ENDPOINT_PREFIX, self.vhost), string(b), ready)
+		if err != nil {
+			plog.Error("Failed to register service")
 		}
-		cli, err := self.getClient()
+		time.Sleep(time.Duration(serverConfig.Etcd.ServiceHeartbeat) * time.Second)
+	}
+}
+
+func (self *EtcdStorage) GetEndpoint(vhost string) (*EndpointConfig, error) {
+	fmt.Println(EtcdKeyJoin(ENDPOINT_PREFIX, vhost))
+	b, err := self.client.Get(EtcdKeyJoin(ENDPOINT_PREFIX, vhost))
+	if err != nil {
+		return nil, err
+	}
+	config := new(EndpointConfig)
+	err = json.Unmarshal(b, config)
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	return config, nil
+}
+
+func (self *EtcdStorage) GetVhosts() (map[string]*EndpointConfig, error) {
+	m, err := self.client.List(EtcdKeyJoin(ENDPOINT_PREFIX))
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]*EndpointConfig)
+	for k, v := range m {
+		config := new(EndpointConfig)
+		err = json.Unmarshal([]byte(v), config)
 		if err != nil {
 			plog.Error(err)
+			return nil, err
 		}
-		defer cli.Close()
-		for {
-			time.Sleep(time.Duration(t) * time.Second)
-			_, err = cli.KeepAliveOnce(context.TODO(), resp.ID)
-			if err != nil {
-				plog.Error(fmt.Sprintf("Could not update host on etcd, error: %s", err))
-			}
-		}
-	}()
-	return nil
-}
-
-func (self *EtcdStorage) getHosts(cli *clientv3.Client) ([]string, error) {
-	var err error
-	if cli == nil {
-		return nil, common.ErrETCDNotInit
+		temp := strings.Split(k, "/")
+		vhost := temp[len(temp)-1]
+		ret[vhost] = config
 	}
-	resp, err := cli.Get(context.TODO(), "/goconserver/hosts", clientv3.WithPrefix())
-	if err != nil {
-		return nil, err
-	}
-	hosts := make([]string, 0, len(resp.Kvs))
-	for _, v := range resp.Kvs {
-		hosts = append(hosts, string(v.Value))
-	}
-	return hosts, nil
-}
-
-func (self *EtcdStorage) getClient() (*clientv3.Client, error) {
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   self.endpoints,
-		DialTimeout: self.dialTimeout,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return cli, nil
+	return ret, nil
 }
 
 func (self *EtcdStorage) ImportNodes() {
-	dirKey := fmt.Sprintf("/goconserver/%s/nodes", self.host)
-	cli, err := self.getClient()
+	kvs, err := self.client.List(EtcdKeyJoin(NODE_PREFIX, self.vhost))
 	if err != nil {
-		plog.Error(err)
-		return
+		plog.Error(fmt.Sprintf("Unable to import node from storage, Error: %s", err))
+		panic(err)
 	}
-	defer cli.Close()
-	resp, err := cli.Get(context.TODO(), dirKey, clientv3.WithPrefix())
-	if err != nil {
-		plog.Error(err)
-		return
-	}
-	for _, v := range resp.Kvs {
-		node := NewNode()
-		val := v.Value
-		if err := json.Unmarshal(val, node); err != nil {
-			plog.Error(err)
-			continue
-		}
-		if node.Name == "" {
-			plog.Error("Skip this record as node name is not defined")
-			continue
-		}
-		if node.Driver == "" {
-			plog.ErrorNode(node.Name, "Driver is not defined")
+	for _, v := range kvs {
+		node, err := UnmarshalNode([]byte(v))
+		if err != nil {
 			continue
 		}
 		self.Storage.Nodes[node.Name] = node
 	}
 }
 
-func (self *EtcdStorage) getHostCount(cli *clientv3.Client) (map[string]int, error) {
+func (self *EtcdStorage) GetNodeCountEachHost() (map[string]int, error) {
 	var err error
-	if cli == nil {
-		return nil, common.ErrETCDNotInit
+	hosts, err := self.GetVhosts()
+	if err != nil {
+		return nil, err
 	}
-	hosts, err := self.getHosts(cli)
+	nodeCountMap := make(map[string]int)
+	for host, _ := range hosts {
+		nodeCountMap[host], err = self.client.Count(EtcdKeyJoin(NODE_PREFIX, host))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nodeCountMap, nil
+}
+
+func (self *EtcdStorage) ListNodeWithHost() (map[string]string, error) {
+	hosts, err := self.GetVhosts()
 	if err != nil {
 		plog.Error(err)
 		return nil, err
 	}
-	hostsCount := make(map[string]int)
-	for _, host := range hosts {
-		key := fmt.Sprintf("/goconserver/%s/nodes/", host)
-		resp, err := cli.Get(context.TODO(), key, clientv3.WithPrefix(), clientv3.WithCountOnly())
+	nodeToHost := make(map[string]string)
+	for host, _ := range hosts {
+		resp, err := self.client.Keys(EtcdKeyJoin(NODE_PREFIX, host))
 		if err != nil {
-			plog.Error(err)
-			hostsCount[host] = -1
-			continue
+			return nil, err
 		}
-		hostsCount[host] = int(resp.Count)
+		for _, k := range resp {
+			temp := strings.Split(string(k), "/")
+			nodeToHost[temp[len(temp)-1]] = host
+		}
 	}
-	return hostsCount, nil
+	return nodeToHost, nil
 }
 
-func (self *EtcdStorage) getMinHost(hostsCount map[string]int) string {
-	minHost := ""
-	minCount := common.Maxint32
-	for k, v := range hostsCount {
-		if v == -1 {
-			continue
-		}
-		minCount = common.If(v < minCount, v, minCount).(int)
-		if v == minCount {
-			minHost = k
-		}
+func (self *EtcdStorage) NotifyPersist(record interface{}, action int) error {
+	var err error
+	switch action {
+	case ACTION_PUT:
+		err = self.putNode(record)
+	case ACTION_MULTIPUT:
+		err = self.putNodes(record)
+	case ACTION_DEL:
+		err = self.delNode(record)
+	case ACTION_MULTIDEL:
+		err = self.delNodes(record)
 	}
-	return minHost
+	if err != nil {
+		plog.Error(err)
+	}
+	return err
 }
 
-func (self *EtcdStorage) GetHosts() []string {
-	cli, err := self.getClient()
-	if err != nil {
-		plog.Error(err)
-		return nil
-	}
-	defer cli.Close()
-	hosts, err := self.getHosts(cli)
-	if err != nil {
-		plog.Error(err)
-		return nil
-	}
-	return hosts
-}
-
-func (self *EtcdStorage) ListNodeWithHost() map[string]string {
-	cli, err := self.getClient()
-	if err != nil {
-		plog.Error(err)
-		return nil
-	}
-	defer cli.Close()
-	hosts, err := self.getHosts(cli)
-	if err != nil {
-		plog.Error(err)
-		return nil
-	}
-	hostNodes := make(map[string]string)
-	for _, host := range hosts {
-		key := fmt.Sprintf("/goconserver/%s/nodes/", host)
-		resp, err := cli.Get(context.TODO(), key, clientv3.WithPrefix())
-		if err != nil {
-			plog.Error(err)
-			continue
-		}
-		for _, v := range resp.Kvs {
-			if string(v.Key) == key {
-				continue
-			}
-			vals := strings.Split(string(v.Key), "/")
-			hostNodes[vals[len(vals)-1]] = host
-		}
-	}
-	return hostNodes
-}
-
-func (self *EtcdStorage) NotifyPersist(nodes interface{}, action int) {
-	if action == common.ACTION_PUT {
-		if reflect.TypeOf(nodes).Kind() != reflect.Map {
-			plog.Error("The persistance format is not Map, ignore.")
-		}
-		cli, err := self.getClient()
-		if err != nil {
-			plog.Error(err)
-			return
-		}
-		defer cli.Close()
-		hostsCount, err := self.getHostCount(cli)
-		if err != nil {
-			plog.Error(err)
-			return
-		}
-		for _, v := range nodes.(map[string][]Node)["nodes"] {
-			host := self.getMinHost(hostsCount)
-			if host == "" {
-				plog.Error("Could not find proper host")
-				return
-			}
-			key := fmt.Sprintf("/goconserver/%s/nodes/%s", host, v.Name)
-			b, err := json.Marshal(v)
-			if err != nil {
-				plog.ErrorNode(v.Name, err)
-				continue
-			}
-			_, err = cli.Put(context.TODO(), key, string(b))
-			if err != nil {
-				plog.ErrorNode(v.Name, err)
-				continue
-			}
-			hostsCount[host]++
-		}
-	} else if action == common.ACTION_DELETE {
-		if reflect.TypeOf(nodes).Kind() != reflect.Slice {
-			plog.Error("The persistance format is not Slice, ignore.")
-		}
-		cli, err := self.getClient()
-		if err != nil {
-			plog.Error(err)
-			return
-		}
-		defer cli.Close()
-		for _, v := range nodes.([]string) {
-			key := fmt.Sprintf("/goconserver/%s/nodes/%s", self.host, v)
-			_, err = cli.Delete(context.TODO(), key)
-			if err != nil {
-				plog.ErrorNode(v, err)
-				continue
+func (self *EtcdStorage) PersistWatcher(c chan<- interface{}) {
+	key := EtcdKeyJoin(NODE_PREFIX, self.vhost)
+	fc := func(events []*clientv3.Event, c chan<- interface{}) {
+		for _, event := range events {
+			switch event.Type {
+			// put
+			case 0:
+				node, err := UnmarshalNode(event.Kv.Value)
+				if err != nil {
+					plog.Warn(err.Error())
+					continue
+				}
+				c <- NewEventData(ACTION_PUT, node)
+			// del
+			case 1:
+				temp := strings.Split(string(event.Kv.Key), "/")
+				name := temp[len(temp)-1]
+				c <- NewEventData(ACTION_DEL, name)
 			}
 		}
-	} else {
-		plog.Error("Not support")
 	}
-}
-
-func (self *EtcdStorage) PersistWatcher(eventChan chan map[int][]byte) {
-	cli, err := self.getClient()
-	if err != nil {
-		plog.Error(err)
-		return
-	}
-	defer cli.Close()
-	key := fmt.Sprintf("/goconserver/%s/nodes/", self.host)
-	changes := cli.Watch(context.Background(), key, clientv3.WithPrefix())
-	for resp := range changes {
-		for _, ev := range resp.Events {
-			if string(ev.Kv.Key) == key {
-				continue
-			}
-			eventMap := make(map[int][]byte)
-			if ev.Type == common.ACTION_PUT {
-				eventMap[int(ev.Type)] = ev.Kv.Value
-			} else if ev.Type == common.ACTION_DELETE {
-				keys := strings.Split(string(ev.Kv.Key), "/")
-				eventMap[int(ev.Type)] = []byte(keys[len(keys)-1])
-			}
-			eventChan <- eventMap
-		}
-	}
+	self.client.Watch(key, fc, c)
 }
 
 func (self *EtcdStorage) SupportWatcher() bool {
 	return true
+}
+
+func (self *EtcdStorage) putNode(record interface{}) error {
+	var ok bool
+	var node *Node
+	if node, ok = record.(*Node); !ok {
+		return common.ErrInvalidType
+	}
+	dispatcher := newDispatcher(self)
+	host, err := dispatcher.PeekPutHost(node)
+	if err != nil {
+		return nil
+	}
+	key := EtcdKeyJoin(NODE_PREFIX, host, node.Name)
+	b, err := json.Marshal(*node)
+	if err != nil {
+		plog.ErrorNode(node.Name, err)
+		return err
+	}
+	err = self.client.Put(key, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (self *EtcdStorage) putNodes(record interface{}) error {
+	var ok bool
+	var nodes []Node
+	if nodes, ok = record.([]Node); !ok {
+		return common.ErrInvalidType
+	}
+	dispatcher := newDispatcher(self)
+	m, err := dispatcher.PeekPutHostMap(nodes)
+	if err != nil {
+		return err
+	}
+	data := make(map[string]string)
+	for node, host := range m {
+		b, err := json.Marshal(node)
+		if err != nil {
+			plog.ErrorNode(node.Name, err)
+			return err
+		}
+		key := EtcdKeyJoin(NODE_PREFIX, host, node.Name)
+		data[key] = string(b)
+	}
+	err = self.client.MultiPut(data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (self *EtcdStorage) delNode(record interface{}) error {
+	var ok bool
+	var name string
+	if name, ok = record.(string); !ok {
+		return common.ErrInvalidType
+	}
+	dispatcher := newDispatcher(self)
+	host, err := dispatcher.PeekDelHost(name)
+	if err != nil {
+		return err
+	}
+	key := EtcdKeyJoin(NODE_PREFIX, host, name)
+	err = self.client.Del(key)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (self *EtcdStorage) delNodes(record interface{}) error {
+	var ok bool
+	var names []string
+	if names, ok = record.([]string); !ok {
+		return common.ErrInvalidType
+	}
+	dispatcher := newDispatcher(self)
+	hostMap, err := dispatcher.PeekDelHostMap(names)
+	if err != nil {
+		return err
+	}
+	keys := make([]string, len(hostMap))
+	i := 0
+	for name, host := range hostMap {
+		keys[i] = EtcdKeyJoin(NODE_PREFIX, host, name)
+		i++
+	}
+	self.client.MultiDel(keys)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/storage/etcd/client.go
+++ b/storage/etcd/client.go
@@ -1,0 +1,337 @@
+package etcd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/coreos/etcd/pkg/transport"
+	"github.com/xcat2/goconserver/common"
+	"strings"
+	"time"
+)
+
+const (
+	maxOpSize = 128
+)
+
+var (
+	plog = common.GetLogger("github.com/xcat2/goconserver/storage/etcd")
+)
+
+type EtcdClient struct {
+	config *common.EtcdCfg
+	cli    *clientv3.Client
+}
+
+func NewEtcdClient(config *common.EtcdCfg) (*EtcdClient, error) {
+	var err error
+	var tlsInfo transport.TLSInfo
+	var tlsConfig *tls.Config
+	endpoints := strings.Split(config.Endpoints, " ")
+	if len(endpoints) < 1 {
+		plog.Error("Invalid parameter: etcd endpoints, ip/hostname list separated with space should be specified.")
+		return nil, common.ErrInvalidParameter
+	}
+	if config.SSLCertFile == "" && config.SSLKeyFile == "" && config.SSLCertFile == "" {
+		tlsConfig = nil
+	}
+	tlsInfo = transport.TLSInfo{
+		CertFile: config.SSLCertFile,
+		KeyFile:  config.SSLKeyFile,
+		CAFile:   config.SSLCertFile,
+	}
+	tlsConfig, err = tlsInfo.ClientConfig()
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	if config.SSLCertFile == "" || config.SSLKeyFile == "" || config.SSLCertFile == "" {
+		tlsConfig = nil
+	}
+	etcdClient := new(EtcdClient)
+	etcdClient.config = config
+	etcdClient.cli, err = clientv3.New(clientv3.Config{
+		Endpoints:   endpoints[:],
+		DialTimeout: time.Duration(config.DailTimeout) * time.Second,
+		TLS:         tlsConfig,
+	})
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	return etcdClient, nil
+}
+
+func (self *EtcdClient) Close() {
+	self.cli.Close()
+}
+
+func (self *EtcdClient) Get(key string) ([]byte, error) {
+	var err error
+	var resp *clientv3.GetResponse
+	if resp, err = self.cli.Get(context.TODO(), key); err != nil {
+		return nil, err
+	}
+	if len(resp.Kvs) == 0 {
+		plog.Warn(fmt.Sprintf("Could not find key %s", key))
+		return nil, common.ErrNotExist
+	}
+	return resp.Kvs[0].Value, nil
+}
+
+func (self *EtcdClient) Put(key string, val interface{}) error {
+	var err error
+	var s string
+	switch val.(type) {
+	case string:
+		s = val.(string)
+	case []byte:
+		s = string(val.([]byte))
+	default:
+		plog.Error("Invalid type")
+		return common.ErrInvalidType
+	}
+	if _, err = self.cli.Put(context.TODO(), key, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (self *EtcdClient) Del(key string) error {
+	var err error
+	if _, err = self.cli.Delete(context.TODO(), key); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (self *EtcdClient) List(path string) (map[string]string, error) {
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	resp, err := self.cli.Get(context.TODO(), path, clientv3.WithPrefix())
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	ret := make(map[string]string)
+	for _, v := range resp.Kvs {
+		ret[string(v.Key)] = string(v.Value)
+	}
+	return ret, nil
+}
+
+func (self *EtcdClient) Keys(path string) ([]string, error) {
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	resp, err := self.cli.Get(context.TODO(), path, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	ret := make([]string, resp.Count)
+	for i := int64(0); i < resp.Count; i++ {
+		ret[i] = string(resp.Kvs[i].Key)
+	}
+	return ret, nil
+}
+
+func (self *EtcdClient) Count(path string) (int, error) {
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	resp, err := self.cli.Get(context.TODO(), path, clientv3.WithPrefix(), clientv3.WithCountOnly())
+	if err != nil {
+		plog.Error(err)
+		return 0, err
+	}
+	return int(resp.Count), nil
+}
+
+func (self *EtcdClient) MultiPut(m map[string]string) error {
+	var err error
+	var response *clientv3.TxnResponse
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(self.config.RequestTimeout)*time.Second)
+	defer cancel()
+	var ops [][]clientv3.Op
+	block := make([]clientv3.Op, 0)
+	for k, v := range m {
+		block = append(block, clientv3.OpPut(k, v))
+		if len(block) == maxOpSize {
+			ops = append(ops, block)
+			block = make([]clientv3.Op, 0)
+		}
+	}
+	if len(block) != 0 {
+		ops = append(ops, block)
+	}
+	for _, block := range ops {
+		response, err = self.cli.Txn(ctx).Then(block...).Commit()
+		if ctx.Err() == context.DeadlineExceeded {
+			plog.Error("Timeout while execute multiple put operation")
+			return common.ErrTimeout
+		}
+		if err != nil {
+			plog.Error(err)
+			return err
+		}
+		if !response.Succeeded {
+			plog.Error(common.ErrETCDTransaction)
+			return common.ErrETCDTransaction
+		}
+	}
+	return nil
+}
+
+func (self *EtcdClient) MultiGet(m map[string]string) (map[string]string, error) {
+	var err error
+	var response *clientv3.TxnResponse
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(self.config.RequestTimeout)*time.Second)
+	defer cancel()
+	var ops [][]clientv3.Op
+	block := make([]clientv3.Op, 0)
+	for k, _ := range m {
+		block = append(block, clientv3.OpGet(k))
+		if len(block) == maxOpSize {
+			ops = append(ops, block)
+			block = make([]clientv3.Op, 0)
+		}
+	}
+	if len(block) != 0 {
+		ops = append(ops, block)
+	}
+	for _, block := range ops {
+		response, err = self.cli.Txn(ctx).Then(block...).Commit()
+		if ctx.Err() == context.DeadlineExceeded {
+			plog.Error("Timeout while execute multiple get operation")
+			return nil, common.ErrTimeout
+		}
+		if err != nil {
+			plog.Error(err)
+			return nil, err
+		}
+		if !response.Succeeded {
+			plog.Error(common.ErrETCDTransaction)
+			return nil, common.ErrETCDTransaction
+		}
+	}
+	ret := make(map[string]string)
+	for _, v := range response.Responses {
+		item := v.GetResponseRange()
+		if len(item.Kvs) == 0 {
+			continue
+		}
+		kv := item.Kvs[0]
+		ret[string(kv.Key)] = string(kv.Value)
+	}
+	return ret, nil
+}
+
+func (self *EtcdClient) MultiDel(keys []string) error {
+	var err error
+	var response *clientv3.TxnResponse
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(self.config.RequestTimeout)*time.Second)
+	defer cancel()
+	var ops [][]clientv3.Op
+	block := make([]clientv3.Op, 0)
+	for _, k := range keys {
+		block = append(block, clientv3.OpDelete(k))
+		if len(block) == maxOpSize {
+			ops = append(ops, block)
+			block = make([]clientv3.Op, 0)
+		}
+	}
+	if len(block) != 0 {
+		ops = append(ops, block)
+	}
+	for _, block := range ops {
+		response, err = self.cli.Txn(ctx).Then(block...).Commit()
+		if ctx.Err() == context.DeadlineExceeded {
+			plog.Error("Timeout while execute multiple del operation")
+			return common.ErrTimeout
+		}
+		if err != nil {
+			plog.Error(err)
+			return err
+		}
+		if !response.Succeeded {
+			plog.Error(common.ErrETCDTransaction)
+			return common.ErrETCDTransaction
+		}
+	}
+	return nil
+}
+
+func (self *EtcdClient) Lock(path string) (*concurrency.Mutex, error) {
+	session, err := concurrency.NewSession(self.cli)
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	m := concurrency.NewMutex(session, path)
+	if err = m.Lock(context.TODO()); err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	return m, nil
+}
+
+func (self *EtcdClient) Unlock(m *concurrency.Mutex) error {
+	return m.Unlock(context.TODO())
+}
+
+/* Register service in etcd, this method would not return if register service successfully.
+   If keepalive request can not be reached in time, etcd would clear the servicePath entry. */
+func (self *EtcdClient) RegisterAndKeepalive(lockPath string, servicePath string, serviceVal string, ready chan<- struct{}) error {
+	m, err := self.Lock(lockPath)
+	if err != nil {
+		plog.Error(err)
+		return err
+	}
+	_, err = self.Get(servicePath)
+	if err == nil {
+		// has value
+		self.Unlock(m)
+		plog.Warn(fmt.Sprintf("%s:%s", servicePath, common.ErrAlreadyExist.Error()))
+		return common.ErrAlreadyExist
+	}
+	lease := clientv3.NewLease(self.cli)
+	resp, err := lease.Grant(context.TODO(), self.config.ServiceHeartbeat)
+	if err != nil {
+		plog.Error(err)
+		self.Unlock(m)
+		return err
+	}
+	_, err = self.cli.Put(context.TODO(), servicePath, serviceVal, clientv3.WithLease(resp.ID))
+	if err != nil {
+		plog.Error(err)
+		self.Unlock(m)
+		return err
+	}
+	self.Unlock(m)
+	ready <- struct{}{}
+	t := self.config.ServiceHeartbeat / 2
+	if t <= 0 {
+		t = 1
+	}
+	for {
+		self.cli.KeepAlive(context.TODO(), resp.ID)
+		time.Sleep(time.Duration(t) * time.Second)
+	}
+	return nil
+}
+
+func (self *EtcdClient) Watch(path string, fc func([]*clientv3.Event, chan<- interface{}), c chan<- interface{}) {
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	rch := self.cli.Watch(ctx, path, clientv3.WithPrefix())
+	for resp := range rch {
+		fc(resp.Events, c)
+	}
+	cancel()
+}

--- a/storage/file.go
+++ b/storage/file.go
@@ -82,17 +82,21 @@ func (self *FileStorage) ImportNodes() {
 	}
 }
 
-func (self *FileStorage) NotifyPersist(nodes interface{}, action int) {
+func (self *FileStorage) NotifyPersist(nodes interface{}, action int) error {
+	if action != ACTION_NIL {
+		plog.Error(common.ErrUnsupported)
+	}
 	if reflect.TypeOf(nodes).Kind() == reflect.Map {
 		self.Nodes = nodes.(map[string]*Node)
 		common.Notify(self.pending, &self.persistence, 1)
 	} else {
 		plog.Error("Undefine persistance type")
 	}
+	return nil
 }
 
 // a separate thread to save the data, avoid of frequent IO
-func (self *FileStorage) PersistWatcher(eventChan chan map[int][]byte) {
+func (self *FileStorage) PersistWatcher(eventChan chan<- interface{}) {
 	common.Wait(self.pending, &self.persistence, 0, self.save)
 }
 
@@ -130,10 +134,18 @@ func (self *FileStorage) SupportWatcher() bool {
 	return false
 }
 
-func (self *FileStorage) ListNodeWithHost() map[string]string {
-	return nil
+func (self *FileStorage) ListNodeWithHost() (map[string]string, error) {
+	return nil, common.ErrUnsupported
 }
 
-func (self *FileStorage) GetHosts() []string {
-	return nil
+func (self *FileStorage) GetVhosts() (map[string]*EndpointConfig, error) {
+	return nil, common.ErrUnsupported
+}
+
+func (self *FileStorage) GetNodeCountEachHost() (map[string]int, error) {
+	return nil, common.ErrUnsupported
+}
+
+func (self *FileStorage) GetEndpoint(host string) (*EndpointConfig, error) {
+	return nil, common.ErrUnsupported
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,8 +1,17 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/xcat2/goconserver/common"
+)
+
+const (
+	ACTION_MULTIDEL = 4
+	ACTION_DEL      = 3
+	ACTION_MULTIPUT = 2
+	ACTION_PUT      = 1
+	ACTION_NIL      = -1
 )
 
 var (
@@ -11,15 +20,62 @@ var (
 	STORAGE_INIT_MAP = map[string]func() StorInterface{}
 )
 
+type EventData struct {
+	Action int
+	Data   interface{}
+}
+
+func NewEventData(action int, data interface{}) *EventData {
+	return &EventData{Action: action, Data: data}
+}
+
+type EndpointConfig struct {
+	ApiPort     string `json:"api_port"`
+	RpcPort     string `json:"rpc_port"`
+	ConsolePort string `json:"console_port`
+	Host        string `json:"host"`
+}
+
+func NewEndpointConfig(apiPort, rpcPort, consolePort, host string) *EndpointConfig {
+	return &EndpointConfig{ApiPort: apiPort, RpcPort: rpcPort, ConsolePort: consolePort, Host: host}
+}
+
+func (self *EndpointConfig) ToByte() ([]byte, error) {
+	b, err := json.Marshal(self)
+	if err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	return b, nil
+}
+
 type Node struct {
 	Name     string            `json:"name"`
 	Driver   string            `json:"driver"` // node type cmd, ssh, ipmitool
 	Params   map[string]string `json:"params"`
 	Ondemand bool              `json:"ondemand, true"`
+	Labels   map[string]string `json:labels, omitempty`
 }
 
 func NewNode() *Node {
 	return new(Node)
+}
+
+func UnmarshalNode(b []byte) (*Node, error) {
+	node := new(Node)
+	if err := json.Unmarshal(b, node); err != nil {
+		plog.Error(err)
+		return nil, err
+	}
+	if node.Name == "" {
+		plog.Error("Node name is not defined")
+		return nil, common.ErrNodeNotExist
+	}
+	if node.Driver == "" {
+		plog.ErrorNode(node.Name, common.ErrDriverNotExist)
+		return nil, common.ErrDriverNotExist
+	}
+	return node, nil
 }
 
 type Storage struct {
@@ -33,12 +89,14 @@ func (s *Storage) GetNodes() map[string]*Node {
 
 type StorInterface interface {
 	ImportNodes() // import nodes to Storage.Nodes
-	PersistWatcher(eventChan chan map[int][]byte)
-	GetHosts() []string
+	PersistWatcher(eventChan chan<- interface{})
+	GetVhosts() (map[string]*EndpointConfig, error)
+	GetNodeCountEachHost() (map[string]int, error) // key host, value int count
 	GetNodes() map[string]*Node
-	NotifyPersist(interface{}, int)
+	GetEndpoint(host string) (*EndpointConfig, error)
+	NotifyPersist(interface{}, int) error
 	SupportWatcher() bool
-	ListNodeWithHost() map[string]string // key node name, value host
+	ListNodeWithHost() (map[string]string, error) // key node name, value host
 }
 
 func NewStorage(storType string) (StorInterface, error) {


### PR DESCRIPTION
This patch includes the following changes:
1. Add bulk interface for etcd storage plugin
2. Enhance handshake protocol for goconserver console connection
3. Use lease, lock, watch from etcd to support goconserver cluster
4. Console session redirection among goconserver cluster
5. A dispatcher to select the goconserver host and could help
    balance the workload when enrolling node(s) in goconserver service.

task: https://github.com/xcat2/xcat2-task-management/issues/52

In /etc/goconserver/server.conf
```
etcd:
  dail_timeout: 5
  request_timeout: 2
  # multiple endpoints could be apply, separate by the space
  endpoints: 127.0.0.1:2379
  # if timeout, the server host will be unregistered from cluster
  service_heartbeat: 5
  prefix: goconserver
  vhost: LongMacbook1
```
The vhost of the second node is LongMacbook2
```
Longs-MacBook-Pro:goconserver longcheng$ etcdctl get / --prefix
/goconserver/endpoint/LongMacbook1
{"api_port":"12429","rpc_port":"12431","ConsolePort":"12430","host":"127.0.0.1"}
/goconserver/endpoint/LongMacbook2
{"api_port":"12450","rpc_port":"12452","ConsolePort":"12451","host":"127.0.0.1"}
/goconserver/node/LongMacbook1/bulknode1
{"name":"bulknode1","driver":"ssh","params":{"host":"xxx","password":"xxx","port":"22","user":"chenglch"},"ondemand":false,"Labels":null}
/goconserver/node/LongMacbook1/bulknode3
{"name":"bulknode3","driver":"ssh","params":{"host":"xxx","password":"xxx","port":"22","user":"chenglch"},"ondemand":false,"Labels":null}
/goconserver/node/LongMacbook2/bulknode2
{"name":"bulknode2","driver":"ssh","params":{"host":"xxxx","password":"xxxx","port":"22","user":"chenglch"},"ondemand":true,"Labels":null}
/goconserver/node/LongMacbook2/bulknode4
{"name":"bulknode4","driver":"ssh","params":{"host":"xxxx,"password":"xxx","port":"22","user":"chenglch"},"ondemand":true,"Labels":null}

Longs-MacBook-Pro:goconserver longcheng$ congo list
bulknode1 (host: LongMacbook1, state: connected)
bulknode2 (host: LongMacbook2, state: enroll)
bulknode3 (host: LongMacbook1, state: error)
bulknode4 (host: LongMacbook2, state: enroll)

Longs-MacBook-Pro:goconserver longcheng$ congo console bulknode2
[Enter `^Ec?' for help]
goconserver(2018-05-16T17:15:03+08:00): Hello 127.0.0.1:65044, welcome to the session of bulknode2
Last login: Wed May 16 05:12:16 2018 from 9.197.226.121

==============================================================================
                          Welcome to c910loginx03

- root user login has been disabled
- root commands must be issued via sudo commands,  "usermod -G10 <userid>"

==============================================================================
-bash-4.1$
-bash-4.1$ [Disconnected]

Longs-MacBook-Pro:goconserver longcheng$ congo console bulknode1
[Enter `^Ec?' for help]
goconserver(2018-05-16T17:15:23+08:00): Hello 127.0.0.1:65066, welcome to the session of bulknode1

-bash-4.1$
-bash-4.1$
```
