### PR TITLE
Add break sequence framework to support sysrq

### DIFF
--- a/api/escape.go
+++ b/api/escape.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"github.com/xcat2/goconserver/console"
+)
+
+type EscapeApi struct {
+	routes Routes
+}
+
+func NewEscapeApi(router *mux.Router) *CommandApi {
+	api := CommandApi{}
+	routes := Routes{
+		Route{"Command", "GET", "/breaksequence", api.listSequence},
+	}
+	api.routes = routes
+	for _, route := range routes {
+		router.
+			Methods(route.Method).
+			Path(route.Pattern).
+			Name(route.Name).
+			Handler(route.HandlerFunc)
+	}
+	return &api
+}
+
+func (api *CommandApi) listSequence(w http.ResponseWriter, req *http.Request) {
+	plog.Debug(fmt.Sprintf("Receive %s request %s from %s.", req.Method, req.URL.Path, req.RemoteAddr))
+	var resp []byte
+	var err error
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	serverEscape := console.GetServerEscape()
+	if serverEscape == nil {
+		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())
+		return
+	}
+	seqs := serverEscape.GetSequences()
+	if resp, err = json.Marshal(seqs); err != nil {
+		plog.HandleHttp(w, req, http.StatusInternalServerError, err.Error())
+		return
+	}
+	fmt.Fprintf(w, "%s\n", resp)
+}

--- a/common/conf.go
+++ b/common/conf.go
@@ -98,6 +98,11 @@ type EtcdCfg struct {
 	RpcPort string `yaml:"rpcport"`
 }
 
+type BreakSequenceCfg struct {
+	Sequence string `yaml:"sequence"`
+	Delay    int    `yaml:"delay"`
+}
+
 type ServerConfig struct {
 	Global struct {
 		Host          string `yaml:"host"`
@@ -115,16 +120,17 @@ type ServerConfig struct {
 		DistDir     string `yaml:"dist_dir"`
 	}
 	Console struct {
-		Port              string    `yaml:"port"`
-		DataDir           string    `yaml:"datadir"`
-		LogTimestamp      bool      `yaml:"log_timestamp"`
-		TimePrecision     string    `yaml:"time_precision"`
-		TimeFormat        string    `yaml:"-"`
-		ReplayLines       int       `yaml:"replay_lines"`
-		ClientTimeout     int       `yaml:"client_timeout"`
-		TargetTimeout     int       `yaml:"target_timeout"`
-		ReconnectInterval int       `yaml:"reconnect_interval"`
-		Loggers           LoggerCfg `yaml:"logger"`
+		Port              string             `yaml:"port"`
+		DataDir           string             `yaml:"datadir"`
+		LogTimestamp      bool               `yaml:"log_timestamp"`
+		TimePrecision     string             `yaml:"time_precision"`
+		TimeFormat        string             `yaml:"-"`
+		ReplayLines       int                `yaml:"replay_lines"`
+		ClientTimeout     int                `yaml:"client_timeout"`
+		TargetTimeout     int                `yaml:"target_timeout"`
+		ReconnectInterval int                `yaml:"reconnect_interval"`
+		Loggers           LoggerCfg          `yaml:"logger"`
+		BreakSequences    []BreakSequenceCfg `yaml:"break_sequence"`
 	}
 	Etcd EtcdCfg `yaml:"etcd"`
 }

--- a/common/signal.go
+++ b/common/signal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 )
 
 var (
@@ -15,9 +16,11 @@ func DoSignal(done <-chan struct{}) {
 	for {
 		c := make(chan os.Signal)
 		var sigs []os.Signal
+		s.rwLock.RLock()
 		for sig := range s.GetSigMap() {
 			sigs = append(sigs, sig)
 		}
+		s.rwLock.RUnlock()
 		signal.Notify(c, sigs...)
 		select {
 		case sig := <-c:
@@ -35,22 +38,28 @@ func DoSignal(done <-chan struct{}) {
 type SignalHandler func(s os.Signal, arg interface{})
 
 type SignalSet struct {
-	m map[os.Signal]SignalHandler
+	rwLock *sync.RWMutex
+	m      map[os.Signal]SignalHandler
 }
 
 func GetSignalSet() *SignalSet {
 	if signalSet == nil {
 		signalSet = new(SignalSet)
 		signalSet.m = make(map[os.Signal]SignalHandler)
+		signalSet.rwLock = new(sync.RWMutex)
 	}
 	return signalSet
 }
 
 func (set *SignalSet) Register(s os.Signal, handler SignalHandler) {
+	set.rwLock.Lock()
 	set.m[s] = handler
+	set.rwLock.Unlock()
 }
 
 func (set *SignalSet) Handle(sig os.Signal, arg interface{}) (err error) {
+	set.rwLock.RLock()
+	defer set.rwLock.RUnlock()
 	if _, found := set.m[sig]; found {
 		set.m[sig](sig, arg)
 		return nil

--- a/common/utils.go
+++ b/common/utils.go
@@ -304,3 +304,17 @@ func ReadTail(path string, tail int) (string, error) {
 	}
 	return strings.Join(ret[cur:], "\n"), nil
 }
+
+func SafeWrite(writer io.Writer, b []byte) error {
+	n := len(b)
+	tmp := 0
+	for n > 0 {
+		count, err := writer.Write(b[tmp:])
+		if err != nil {
+			return err
+		}
+		tmp += count
+		n -= count
+	}
+	return nil
+}

--- a/console/cli.go
+++ b/console/cli.go
@@ -306,7 +306,6 @@ func (c *CongoCli) waitInput(args interface{}) {
 		terminal.Restore(int(os.Stdin.Fd()), client.origState)
 		if exit == true {
 			if err == nil {
-				fmt.Printf("Disconnected\n")
 				os.Exit(0)
 			} else {
 				fmt.Fprintf(os.Stderr, err.Error())
@@ -345,7 +344,14 @@ func (c *CongoCli) waitInput(args interface{}) {
 			exit = true
 			return
 		}
-		exit, _ = client.checkEscape(b, n, "")
+		err = client.processClientSession(nil, b, n, "")
+		if err != nil {
+			fmt.Printf("\r\nError : %s\r\n", err.Error())
+			return
+		}
+		if client.retry == false {
+			exit = true
+		}
 	}
 }
 
@@ -361,6 +367,7 @@ func (c *CongoCli) console(cmd *cobra.Command, args []string) {
 	}
 	retry := true
 	common.NewTaskManager(100, 16)
+	clientEscape = NewEscapeClientSystem()
 	for retry {
 		client, conn, err := initConsoleSessionClient(args[0], clientConfig.ServerHost, clientConfig.ConsolePort)
 		if err != nil {

--- a/console/escape.go
+++ b/console/escape.go
@@ -1,0 +1,342 @@
+package console
+
+import (
+	"fmt"
+	"github.com/xcat2/goconserver/common"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	ESCAPE_CTRL_E     = '\x05'
+	ESCAPE_C          = 'c'
+	CLIENT_CMD_EXIT   = '.'
+	CLIENT_CMD_HELP   = '?'
+	CLIENT_CMD_REPLAY = 'r'
+	CLIENT_CMD_WHO    = 'w'
+	CLIENT_CMD_LOCAL  = 'l'
+
+	SEARCH_BUF_SIZE = 8
+)
+
+var (
+	EXIT_SEQUENCE = [...]byte{ESCAPE_CTRL_E, ESCAPE_C, '.'} // ctrl-e, c
+	clientEscape  *EscapeClientSystem
+	serverEscape  *EscapeServerSystem
+)
+
+type EscapeClientHandler func(net.Conn, interface{}, string, byte) error
+type EscapeServerHandler func(io.Writer, byte) error
+
+func serverBreakSequenceHandler(writer io.Writer, last byte) error {
+	var err error
+	// slice start from 0, but the escape key start from 1
+	sequence := serverEscape.sequences[last-'0'-1]
+	for _, ch := range sequence.seqs {
+		err = common.SafeWrite(writer, []byte{byte(ch)})
+		if err != nil {
+			plog.Error(err)
+			return err
+		}
+		time.Sleep(time.Duration(sequence.delay) * time.Microsecond)
+	}
+	return nil
+}
+
+func clientBreakSequenceHandler(conn net.Conn, c interface{}, node string, last byte) error {
+	printBreakSequence(last)
+	if conn == nil {
+		return nil
+	}
+	if last == '?' {
+		congo := NewCongoClient(clientConfig.HTTPUrl)
+		ret, err := congo.listBreakSequence()
+		if err != nil {
+			printFatalErr(err)
+			return err
+		}
+		for _, s := range ret {
+			fmt.Printf("%s\r\n", s)
+		}
+		return nil
+	}
+	err := common.Network.SendByteWithLength(conn.(net.Conn), []byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_LOCAL, last})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func clientEscapeExitHandler(conn net.Conn, c interface{}, node string, last byte) error {
+	var err error
+	client := c.(*ConsoleClient)
+	client.close()
+	if conn != nil {
+		err = common.Network.SendByteWithLength(conn.(net.Conn), EXIT_SEQUENCE[0:])
+		if err != nil {
+			return err
+		}
+	}
+	client.retry = false
+	printConsoleDisconnectPrompt()
+	return nil
+}
+
+func clientEscapeHelpHandler(conn net.Conn, c interface{}, node string, last byte) error {
+	printConsoleHelpMsg()
+	return nil
+}
+
+func clientEscapeReplayHandler(conn net.Conn, c interface{}, node string, last byte) error {
+	congo := NewCongoClient(clientConfig.HTTPUrl)
+	ret, err := congo.replay(node)
+	if err != nil {
+		if ret != "" {
+			printConsoleCmdErr(ret)
+		} else {
+			printConsoleCmdErr(err)
+		}
+		return err
+	}
+	printConsoleReplay(ret)
+	return nil
+}
+
+func clientEscapeWhoHandler(conn net.Conn, c interface{}, node string, last byte) error {
+	congo := NewCongoClient(clientConfig.HTTPUrl)
+	ret, err := congo.listUser(node)
+	if err != nil {
+		if ret != nil {
+			printConsoleCmdErr(ret)
+		} else {
+			printConsoleCmdErr(err)
+		}
+		return err
+	}
+	printCRLF()
+	for _, v := range ret["users"].([]interface{}) {
+		printConsoleUser(v.(string))
+	}
+	return nil
+}
+
+type EscapeSearcher struct {
+	node *EscapeNode
+	len  int
+	buf  [SEARCH_BUF_SIZE]byte
+}
+
+func NewEscapeSearcher(root *EscapeNode) *EscapeSearcher {
+	return &EscapeSearcher{node: root, len: 0}
+}
+
+type EscapeNode struct {
+	next     map[byte]*EscapeNode
+	refCount int
+	handler  interface{}
+}
+
+func NewEscapeNode() *EscapeNode {
+	return &EscapeNode{refCount: 1, handler: nil, next: make(map[byte]*EscapeNode)}
+}
+
+type BreakSequence struct {
+	seqs  string
+	delay int // ms
+}
+
+func NewBreakSequence(seqs string, delay int) *BreakSequence {
+	return &BreakSequence{
+		seqs:  seqs,
+		delay: delay,
+	}
+}
+
+type EscapeSystem struct {
+	rwLock *sync.RWMutex
+	root   *EscapeNode
+}
+
+func (self *EscapeSystem) Register(s []byte, handler interface{}) {
+	if len(s) == 0 {
+		return
+	}
+	var ok bool
+	var node *EscapeNode
+	self.root.refCount++
+	entry := self.root
+	self.rwLock.Lock()
+	defer self.rwLock.Unlock()
+	for _, ch := range s {
+		if node, ok = entry.next[ch]; !ok {
+			node = NewEscapeNode()
+			entry.next[ch] = node
+		} else {
+			node.refCount++
+		}
+		entry = node
+	}
+	node.handler = handler
+}
+
+func (self *EscapeSystem) exist(s []byte) bool {
+	if len(s) == 0 {
+		return false
+	}
+	var ok bool
+	entry := self.root
+	self.rwLock.RLock()
+	defer self.rwLock.RUnlock()
+	for _, ch := range s {
+		if entry, ok = entry.next[ch]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (self *EscapeSystem) Unregister(s []byte) error {
+	if !self.exist(s) {
+		return common.ErrNotExist
+	}
+	self.root.refCount--
+	var ok bool
+	var node *EscapeNode
+	self.rwLock.Lock()
+	defer self.rwLock.Unlock()
+	entry := self.root
+	for _, ch := range s {
+		if node, ok = entry.next[ch]; !ok {
+			return common.ErrNotExist
+		}
+		entry.refCount--
+		delete(entry.next, ch)
+		entry = node
+	}
+	return nil
+}
+
+type EscapeClientSystem struct {
+	*EscapeSystem
+}
+
+func NewEscapeClientSystem() *EscapeClientSystem {
+	escapeSystem := &EscapeSystem{
+		root:   NewEscapeNode(),
+		rwLock: new(sync.RWMutex),
+	}
+	escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_EXIT}, clientEscapeExitHandler)
+	escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_HELP}, clientEscapeHelpHandler)
+	escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_REPLAY}, clientEscapeReplayHandler)
+	escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_WHO}, clientEscapeWhoHandler)
+	for i := 1; i <= 9; i++ {
+		escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_LOCAL, byte(i) + '0'}, clientBreakSequenceHandler)
+	}
+	escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_LOCAL, '?'}, clientBreakSequenceHandler)
+	return &EscapeClientSystem{escapeSystem}
+}
+
+// Search and cache the charactor
+// return buffered, if return true, this character has been buffered in searcher
+func (self *EscapeClientSystem) Search(conn net.Conn, b byte, searcher *EscapeSearcher) (bool, EscapeClientHandler, error) {
+	var ok bool
+	self.rwLock.RLock()
+	defer self.rwLock.RUnlock()
+	if searcher.node, ok = searcher.node.next[b]; !ok {
+		searcher.node = self.root
+		if conn != nil && searcher.len != 0 {
+			// if the character is not found, send the buffer to the remote and clear the buffer
+			err := common.Network.SendByteWithLength(conn, searcher.buf[:searcher.len])
+			if err != nil {
+				// do not has buffer to send
+				return false, nil, err
+			}
+		}
+		searcher.len = 0
+		return false, nil, nil
+	}
+	if searcher.len == SEARCH_BUF_SIZE {
+		return false, nil, common.ErrOutOfQuota
+	}
+	searcher.buf[searcher.len] = b
+	searcher.len++
+	if searcher.node.handler != nil {
+		searcher.len = 0
+		// match the pattern, return handler, no buffer to send
+		return false, searcher.node.handler.(func(net.Conn, interface{}, string, byte) error), nil
+	}
+	// this character has been add to the search buffer
+	return true, nil, nil
+}
+
+type EscapeServerSystem struct {
+	*EscapeSystem
+	sequences []*BreakSequence
+}
+
+func NewEscapeServerSystem() *EscapeServerSystem {
+	escapeSystem := &EscapeSystem{
+		root:   NewEscapeNode(),
+		rwLock: new(sync.RWMutex),
+	}
+	breakSequences := make([]*BreakSequence, 9)
+	i := 1
+	for _, sequence := range serverConfig.Console.BreakSequences {
+		escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_LOCAL, byte(i) + '0'}, serverBreakSequenceHandler)
+		breakSequences[i-1] = NewBreakSequence(sequence.Sequence, sequence.Delay)
+		i++
+	}
+	for i <= 9 {
+		escapeSystem.Register([]byte{ESCAPE_CTRL_E, ESCAPE_C, CLIENT_CMD_LOCAL, byte(i) + '0'}, serverBreakSequenceHandler)
+		breakSequences[i-1] = NewBreakSequence("~B", 250)
+		i++
+	}
+	return &EscapeServerSystem{escapeSystem, breakSequences}
+}
+
+func (self *EscapeServerSystem) GetSequences() []string {
+	ret := make([]string, len(self.sequences))
+	for i := 0; i < len(self.sequences); i++ {
+		ret[i] = fmt.Sprintf("key: %d string: %s, delay: %d", i+1, self.sequences[i].seqs, self.sequences[i].delay)
+	}
+	return ret
+}
+
+// return buffered, if return true, this character has been buffered in searcher
+func (self *EscapeServerSystem) Search(writer io.Writer, b byte, searcher *EscapeSearcher) (bool, EscapeServerHandler, error) {
+	var ok bool
+	var err error
+	self.rwLock.RLock()
+	defer self.rwLock.RUnlock()
+	if searcher.node, ok = searcher.node.next[b]; !ok {
+		searcher.node = self.root
+		// if the character is not found, send the buffer to the remote and clear the buffer
+		if searcher.len > 0 {
+			err = common.SafeWrite(writer, searcher.buf[:searcher.len])
+			if err != nil {
+				plog.Error(err)
+				return false, nil, err
+			}
+		}
+		searcher.len = 0
+		return false, nil, nil
+	}
+	if searcher.len == SEARCH_BUF_SIZE {
+		return false, nil, common.ErrOutOfQuota
+	}
+	searcher.buf[searcher.len] = b
+	searcher.len++
+	if searcher.node.handler != nil {
+		searcher.len = 0
+		// match the pattern, return handler, no buffer to send
+		return false, searcher.node.handler.(func(io.Writer, byte) error), nil
+	}
+	// this character has been add to the search buffer
+	return true, nil, nil
+}
+
+func GetServerEscape() *EscapeServerSystem {
+	return serverEscape
+}

--- a/console/message.go
+++ b/console/message.go
@@ -32,10 +32,16 @@ func printConsoleSendErr(err error) {
 
 func printConsoleHelpMsg() {
 	fmt.Printf("\r\nHelp message from congo:\r\n" +
-		"Ctrl + e + c + .         Exit from console session  \r\n" +
-		"Ctrl + e + c + ?         Print the help message for console command \r\n" +
-		"Ctrl + e + c + r         Replay last lines (only for file_logger) \r\n" +
-		"Ctrl + e + c + w         Who is on this session \r\n")
+		"Ctrl + e + c + .                 Exit from console session\r\n" +
+		"Ctrl + e + c + ?                 Print the help message for console command\r\n" +
+		"Ctrl + e + c + r                 Replay last lines (only for file_logger)\r\n" +
+		"Ctrl + e + c + w                 Who is on this session\r\n" +
+		"Ctrl + e + c + l + [1-9]/?       Send break sequence to the remote\r\n")
+}
+
+func printBreakSequence(last byte) {
+	s := string([]byte{'^', 'E', ESCAPE_C, CLIENT_CMD_LOCAL, last})
+	fmt.Printf("\r\nBreak sequence %s pressed\r\n", s)
 }
 
 func printConsoleCmdErr(msg interface{}) {

--- a/console/server.go
+++ b/console/server.go
@@ -425,6 +425,7 @@ func GetNodeManager() *NodeManager {
 		if err != nil {
 			panic(err)
 		}
+		serverEscape = NewEscapeServerSystem()
 		// for linelogger to send the last buffer
 		go nodeManager.PeriodicTask()
 		runtime.GOMAXPROCS(serverConfig.Global.Worker)

--- a/etc/goconserver/server.conf
+++ b/etc/goconserver/server.conf
@@ -83,6 +83,15 @@ console:
   # retry interval in second if console could not be connected.
   reconnect_interval: 10
 
+  # define break sequences
+  break_sequence:
+    # ipmi break sequence, press Ctrl + e + c + l + 1 to activate
+    - sequence: ~B
+      delay: 250
+    # press Ctrl + e + c + l + 2 to activate
+    - sequence: "+\d+\d+"
+      delay: 300
+
 # below is experimental option for etcd storage
 etcd:
   dail_timeout: 5

--- a/goconserver.go
+++ b/goconserver.go
@@ -71,6 +71,7 @@ func main() {
 	api.Router = mux.NewRouter().StrictSlash(true)
 	api.NewNodeApi(api.Router)
 	api.NewCommandApi(api.Router)
+	api.NewEscapeApi(api.Router)
 	if serverConfig.API.DistDir != "" {
 		api.RegisterBackendHandler(api.Router)
 	}


### PR DESCRIPTION
Support at most 9 break sequences which can be invoked with
'Ctrl + e + c + l + [1-9]'. By default all of the break sequences
are '~B'.
This patch includes the following:

1. Design prefix tree framework to help register and search the
   sequence keys.
2. Support define break sequences in server.conf
3. Add sequence handler at both server and client side
4. Add rest api and console command to list the break sequences.
    Ctrl + e + c + l + ?

TODO: Manage the sequence keys definition via rest api and store
them in etcd.

task: https://github.com/xcat2/xcat2-task-management/issues/97