### PR TITLE
Add frontend dist into package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 GOPATH?=$(shell pwd)
 export GOPATH
-PATH+=:$(shell pwd)/bin
-export PATH
 GITHUB_DIR=${GOPATH}/src/github.com/xcat2/
 REPO_DIR=${GOPATH}/src/github.com/xcat2/goconserver
 CURRENT_DIR=$(shell pwd)
@@ -11,6 +9,7 @@ SERVER_CONF_FILE=/etc/goconserver/server.conf
 CLIENT_CONF_FILE=~/congo.sh
 SERVER_BINARY=goconserver
 CLIENT_BINARY=congo
+SHELL=/bin/bash
 COMMIT=$(shell git rev-parse HEAD)
 ARCH=$(shell uname -m)
 PLATFORM=$(shell uname)
@@ -70,12 +69,13 @@ install: build
 		cp etc/goconserver/client.sh /etc/profile.d/congo.sh; \
 	fi
 
-tar: build
+tar: build frontend
 	mkdir -p build/goconserver_${PLATFORM}_${ARCH}; \
 	cp -r etc build/goconserver_${PLATFORM}_${ARCH}; \
 	cp -r scripts build/goconserver_${PLATFORM}_${ARCH}; \
 	cp ${SERVER_BINARY} build/goconserver_${PLATFORM}_${ARCH}; \
 	cp ${CLIENT_BINARY} build/goconserver_${PLATFORM}_${ARCH}; \
+	cp -r build/dist build/goconserver_${PLATFORM}_${ARCH}; \
 	cd build/goconserver_${PLATFORM}_${ARCH}; \
 	ln -s scripts/setup.sh setup.sh; \
 	cd - ;\

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ api interface.
 ### Storage plugins
 
 - file: Store the host information in a json file.
-- etcd: Support goconserver cluster [experimental].
+- etcd: Support goconserver cluster.
 
 ### Multiple client types
 
@@ -114,6 +114,7 @@ Setup nodejs(9.0+) and npm(5.6.0+) toolkit at first. An example steps could be
 found at [node env](/frontend/). Then follow the steps below:
 
 ```
+yum install gcc-c++
 npm install -g gulp webpack webpack-cli
 make frontend
 ```

--- a/dirty-rpmbuild
+++ b/dirty-rpmbuild
@@ -112,6 +112,7 @@ mkdir -p \$RPM_BUILD_ROOT/%{prefix}
 %config(noreplace) /etc/profile.d/congo.sh
 /etc/goconserver
 %config(noreplace) /etc/goconserver/server.conf
+/usr/share/goconserver/dist/
 /usr/lib/systemd/system/goconserver.service
 /usr/bin/goconserver
 /usr/bin/congo

--- a/prep-tarball
+++ b/prep-tarball
@@ -86,10 +86,12 @@ mkdir -p "${TMP_DIR}/repack/usr/bin"
 mkdir -p "${TMP_DIR}/repack/usr/lib/systemd/system"
 mkdir -p "${TMP_DIR}/repack/var/log/goconserver/nodes"
 mkdir -p "${TMP_DIR}/repack/var/lib/goconserver"
+mkdir -p "${TMP_DIR}/repack/usr/share/goconserver/dist"
 chmod 0700 "${TMP_DIR}/repack/etc/goconserver" \
 	"${TMP_DIR}/repack/var/log/goconserver" \
 	"${TMP_DIR}/repack/var/log/goconserver/nodes" \
-	"${TMP_DIR}/repack/var/lib/goconserver"
+	"${TMP_DIR}/repack/var/lib/goconserver" \
+	"${TMP_DIR}/repack/usr/share/goconserver"
 install -o root -g root -m 0755 \
 	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/goconserver" \
 	"${TMP_DIR}/repack/usr/bin"
@@ -105,6 +107,9 @@ install -o root -g root -m 0644 \
 install -o root -g root -m 0644 \
 	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/etc/systemd/goconserver.service" \
 	"${TMP_DIR}/repack/usr/lib/systemd/system"
+install -o root -g root -m 0644 -D \
+	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/dist/"* \
+	"${TMP_DIR}/repack/usr/share/goconserver/dist"
 
 ( cd "${TMP_DIR}/repack" && tar cfz - *) >"${GOCONSERVER_REPACK_TARBALL}"
 


### PR DESCRIPTION
From v0.3.0, goconserver support a simple web interface, this patch
add the static files info tar, deb and rpm packages.