### PR TITLE
Use client cert to access grpc server

### DIFF
--- a/common/conf.go
+++ b/common/conf.go
@@ -94,8 +94,12 @@ type EtcdCfg struct {
 	SSLCertFile      string `yaml:"ssl_cert_file"`
 	SSLCACertFile    string `yaml:"ssl_ca_cert_file"`
 	// vhost is the name registered in etcd service, by default it is the hostname
-	Vhost   string `yaml:"vhost`
-	RpcPort string `yaml:"rpcport"`
+	Vhost               string `yaml:"vhost`
+	RpcPort             string `yaml:"rpcport"`
+	RpcClientKeyFile    string `yaml:"rpc_client_key_file"`
+	RpcClientCertFile   string `yaml:"rpc_client_cert_file"`
+	RpcClientCACertFile string `yaml:"rpc_client_ca_cert_file"`
+	RpcInsucure         bool   `yaml:"rpc_insucure"`
 }
 
 type BreakSequenceCfg struct {

--- a/console/rpc.go
+++ b/console/rpc.go
@@ -146,13 +146,13 @@ func (self *ConsoleRpcClient) connect() (*grpc.ClientConn, error) {
 	var creds credentials.TransportCredentials
 	var err error
 	var conn *grpc.ClientConn
-	if serverConfig.Global.SSLCACertFile != "" && serverConfig.Global.SSLKeyFile != "" && serverConfig.Global.SSLCertFile != "" {
+	if serverConfig.Etcd.RpcClientCACertFile != "" && serverConfig.Etcd.RpcClientKeyFile != "" && serverConfig.Etcd.RpcClientCertFile != "" {
 		tlsConfig, err := common.LoadClientTlsConfig(
-			serverConfig.Global.SSLCertFile,
-			serverConfig.Global.SSLKeyFile,
-			serverConfig.Global.SSLCACertFile,
+			serverConfig.Etcd.RpcClientCertFile,
+			serverConfig.Etcd.RpcClientKeyFile,
+			serverConfig.Etcd.RpcClientCACertFile,
 			self.host,
-			false)
+			serverConfig.Etcd.RpcInsucure)
 		if err != nil {
 			panic(err)
 		}

--- a/etc/goconserver/server.conf
+++ b/etc/goconserver/server.conf
@@ -87,10 +87,9 @@ console:
   break_sequence:
     # ipmi break sequence, press Ctrl + e + c + l + 1 to activate
     - sequence: ~B
+      delay: 600
+    - sequence: +\d+\d+
       delay: 250
-    # press Ctrl + e + c + l + 2 to activate
-    - sequence: "+\d+\d+"
-      delay: 300
 
 # below is experimental option for etcd storage
 etcd:
@@ -105,6 +104,8 @@ etcd:
 
   # port for grpc server to support goconserver cluster, only available if storage_type is set to etcd.
   rpcport: 12431
+  # client do not verify the certificate of server, workaround for xcat certificate
+  rpc_insucure: true
 
   # the host name registered in the etcd service with business purpose
   # it could be used for HA purpose
@@ -119,3 +120,10 @@ etcd:
 
   # ssl/tsl ca cert file for etcd
   # ssl_ca_cert_file: /etc/goconserver/cert/ca.pem
+
+  # key file for rpc client
+  # rpc_client_key_file: /root/.xcat/client-key.pem
+  # cert file for rpc client
+  # rpc_client_cert_file: /root/.xcat/client-cred.pem
+  # ca cert file for rpc client
+  # rpc_client_ca_cert_file: /root/.xcat/ca.pem

--- a/storage/etcd.go
+++ b/storage/etcd.go
@@ -59,7 +59,7 @@ func newEtcdStorage() StorInterface {
 		etcdStor.vhost = hostname
 	}
 	etcdStor.host = serverConfig.Global.Host
-	if etcdStor.host == "" {
+	if etcdStor.host == "" || etcdStor.host == "0.0.0.0" {
 		etcdStor.host = hostname
 	}
 	// As client is used to send keepalive request, the client would not be closed
@@ -79,8 +79,9 @@ func (self *EtcdStorage) keepalive(ready chan<- struct{}) {
 	if err != nil {
 		panic(err)
 	}
+	s := string(b)
 	for {
-		err := self.client.RegisterAndKeepalive(EtcdKeyJoin(LOCK_PREFIX, self.vhost), EtcdKeyJoin(ENDPOINT_PREFIX, self.vhost), string(b), ready)
+		err := self.client.RegisterAndKeepalive(EtcdKeyJoin(LOCK_PREFIX, self.vhost), EtcdKeyJoin(ENDPOINT_PREFIX, self.vhost), s, ready)
 		if err != nil {
 			plog.Error("Failed to register service")
 		}


### PR DESCRIPTION
This patch fix the bug that fail to connect to the grpc server due
to the certificate error.