### PR TITLE
Fix the systemd unit file error

### DIFF
--- a/etc/systemd/goconserver.service
+++ b/etc/systemd/goconserver.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=goconserver console daemon
 Documentation=https://github.com/xcat2/goconserver
+After=network.target
 
 [Service]
 LimitNOFILE=65535
@@ -8,7 +9,6 @@ ExecStart=/usr/bin/goconserver
 ExecStop=/bin/kill -TERM $MAINPID
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
-After=network.target
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To fix #24 

UT:
```
systemctl status goconserver
* goconserver.service - goconserver console daemon
   Loaded: loaded (/usr/lib/systemd/system/goconserver.service; disabled; vendor preset: disabled)
   Active: active (running) since Fri 2018-07-20 00:30:10 EDT; 2s ago
     Docs: https://github.com/xcat2/goconserver
 Main PID: 15222 (goconserver)
   CGroup: /system.slice/goconserver.service
           `-15222 /usr/bin/goconserver

Jul 20 00:30:10 c910f03c05k20 systemd[1]: Started goconserver console daemon.
Jul 20 00:30:10 c910f03c05k20 systemd[1]: Starting goconserver console daemon...
Jul 20 00:30:10 c910f03c05k20 goconserver[15222]: goconserver daemon service
```