### PR TITLE
goconserver miss the last \n when send message to log file

### DIFF
--- a/console/pipeline/logger.go
+++ b/console/pipeline/logger.go
@@ -210,6 +210,7 @@ func (self *ByteLogger) insertStamp(b []byte, newLine *bool) ([]byte, error) {
 			*newLine = false
 		}
 		if b[i] == '\n' {
+                       // add 1 to the index in order to also write the newline characater. Slicing of the array only contains p to i-1 if not add 1
 			buf.Write(b[p:i+1])
 			*newLine = true
 			p = i + 1

--- a/console/pipeline/logger.go
+++ b/console/pipeline/logger.go
@@ -206,11 +206,11 @@ func (self *ByteLogger) insertStamp(b []byte, newLine *bool) ([]byte, error) {
 	}()
 	for i := 0; i < len(b); i++ {
 		if *newLine {
-			buf.WriteString("\n[" + time.Now().Format(common.RFC3339_SECOND) + "] ")
+			buf.WriteString("[" + time.Now().Format(common.RFC3339_SECOND) + "] ")
 			*newLine = false
 		}
 		if b[i] == '\n' {
-			buf.Write(b[p:i])
+			buf.Write(b[p:i+1])
 			*newLine = true
 			p = i + 1
 		}


### PR DESCRIPTION
Resolves #52 
(Internal discussion here (private repo): https://github.ibm.com/vhu/c910env/issues/431)

The '\n' of the last message is missed in log file for some case. 
```
# cat goconser.log_beforefix

[2018-10-23T23:06:12-04:00] [897286.719761] NVRM: Xid (PCI:0035:03:00): 63, Dynamic Page Retirement: New page retired, reboot to activate (0x000000000019a8b2).
[2018-10-23T23:06:12-04:00] [1044466.923202] mlx5_0:mr_umem_get:769:(pid 77418): umem get failed (-512).
[2018-10-23T23:06:12-04:00] [897286.719761] NVRM: Xid (PCI:0035:03:00): 63, Dynamic Page Retirement: New page retired, reboot to activate (0x000000000019a8b2).
[2018-10-23T23:06:12-04:00] [1044466.923202] mlx5_0:mr_umem_get:769:(pid 77418): umem get failed (-512).[root@boston36 go_logger]#
```
With this fix, the output shall be like this:
```
# cat goconser.log_withfix
[2018-10-23T23:07:51-04:00] [897286.719761] NVRM: Xid (PCI:0035:03:00): 63, Dynamic Page Retirement: New page retired, reboot to activate (0x000000000019a8b2).
[2018-10-23T23:07:51-04:00] [1044466.923202] mlx5_0:mr_umem_get:769:(pid 77418): umem get failed (-512).
[2018-10-23T23:07:51-04:00] [897286.719761] NVRM: Xid (PCI:0035:03:00): 63, Dynamic Page Retirement: New page retired, reboot to activate (0x000000000019a8b2).
[2018-10-23T23:07:51-04:00] [1044466.923202] mlx5_0:mr_umem_get:769:(pid 77418): umem get failed (-512).
[root@boston36 go_logger]#
```