### PR TITLE
Fix issue 49: goconserver need to restart after upgraded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 ifeq ($(PLATFORM), Linux)
 	PLATFORM=linux
 endif
-VERSION=0.3.1
+VERSION=0.3.2
 BUILD_TIME=`date +%FT%T%z`
 LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.BuildTime=${BUILD_TIME} -X main.Commit=${COMMIT}"
 

--- a/dirty-rpmbuild
+++ b/dirty-rpmbuild
@@ -107,9 +107,8 @@ mkdir -p \$RPM_BUILD_ROOT/%{prefix}
 ( cd \$RPM_BUILD_ROOT/%{prefix} && tar xfz - ) <%{SOURCE0}
 %post
 if [ "\$1" = 2 ]; then
-    if ps axf | grep -v grep | grep \/usr\/bin\/goconserver >/dev/null ; then
-        systemctl restart goconserver.service
-    fi
+    systemctl daemon-reload
+    systemctl try-restart goconserver.service
 fi
 
 %clean

--- a/dirty-rpmbuild
+++ b/dirty-rpmbuild
@@ -105,6 +105,12 @@ goconserver is written in golang and is a part of microservice of xcat3. It can 
 %install
 mkdir -p \$RPM_BUILD_ROOT/%{prefix}
 ( cd \$RPM_BUILD_ROOT/%{prefix} && tar xfz - ) <%{SOURCE0}
+%post
+if [ "\$1" = 2 ]; then
+    if ps axf | grep -v grep | grep \/usr\/bin\/goconserver >/dev/null ; then
+        systemctl restart goconserver.service
+    fi
+fi
 
 %clean
 
@@ -119,6 +125,12 @@ mkdir -p \$RPM_BUILD_ROOT/%{prefix}
 /var/lib/goconserver
 /var/log/goconserver
 /var/log/goconserver/nodes/
+
+%preun
+if [ "\$1" = 0 ]; then
+    systemctl stop goconserver.service    
+    systemctl disable goconserver.service
+fi
 
 EOF
 


### PR DESCRIPTION
Fix issue #49 for the rpm build side:

Added in the fix:
1. restart goconsever when update
2. stop and disable goconserver if uninstall

Before fix:
1. goconserver is not stoped after uninstall goconserver
```
[root@briggs01 tmp]# ps aux |grep -i goconserver
root      49034  0.1  0.0 789696 18752 ?        Ssl  07:35   0:00 /usr/bin/goconserver
root      49980  0.0  0.0 110976  2688 pts/0    S+   07:39   0:00 grep --color=auto -i goconserver
[root@briggs01 tmp]# file /usr/bin/goconserver
/usr/bin/goconserver: cannot open (No such file or directory)
```
2. update goconserver won't restart goconserver:
```
[root@briggs01 tmp]# date
Mon Oct 29 07:49:59 EDT 2018
[root@briggs01 tmp]# rpm -U goconserver-0.3.1-snap201810230740.ppc64le.rpm
warning: /etc/goconserver/server.conf created as /etc/goconserver/server.conf.rpmnew
# rcons mid05tor12cn03
[Enter `^Ec?' for help]
goconserver(2018-10-29T07:47:39-04:00): Hello 10.6.27.1:47146, welcome to the session of mid05tor12cn03

[root@mid05tor12cn03 ~]#
[root@mid05tor12cn03 ~]#
[root@mid05tor12cn03 ~]#
```

With the fix:
1. for update:
```
[root@briggs01 tmp]# date
Tue Oct 30 03:12:44 EDT 2018
[root@briggs01 tmp]# rpm -Uvh goconserver-0.3.2-snap201810300711.ppc64le.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:goconserver-0.3.2-snap20181030071################################# [ 50%]
Cleaning up / removing...
   2:goconserver-0.3.1-snap20181029123################################# [100%]
[root@briggs01 ~]# rcons mid05tor12cn03 -f
[Enter `^Ec?' for help]
goconserver(2018-10-30T03:12:59-04:00): Hello 10.6.27.1:33276, welcome to the session of mid05tor12cn03

Could not receive message, error: EOF.
[Enter `^Ec.' to exit]
Session is teminated unexpectedly, retrying....
[Enter `^Ec?' for help]
goconserver(2018-10-30T03:13:28-04:00): Hello 10.6.27.1:33364, welcome to the session of mid05tor12cn03
```
2. for uninstall:
```
# rcons mid05tor12cn03
[Enter `^Ec?' for help]
goconserver(2018-10-29T08:28:04-04:00): Hello 10.6.27.1:54262, welcome to the session of mid05tor12cn03

Could not receive message, error: EOF.
[Enter `^Ec.' to exit]
Session is teminated unexpectedly, retrying....
Fatal error: dial tcp 10.6.27.1:12430: connect: connection refused[root@briggs01 ~]#
```