### PR TITLE
add keyboard-interactive auth method

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -22,8 +22,6 @@ imports:
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/kr/pty
   version: 95d05c1eef33a45bd58676b6ce28d105839b8d0b
-- name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/spf13/cobra
   version: 7b2c5ac9fc04fc5efafb60700713d4fa609b777b
 - name: github.com/spf13/pflag

--- a/plugins/ssh.go
+++ b/plugins/ssh.go
@@ -104,6 +104,11 @@ func (self *SSHConsole) appendPasswordAuthMethod(autoMethods *[]ssh.AuthMethod) 
 		*autoMethods = append(*autoMethods, ssh.Password(self.password))
 	}
 }
+func (self *SSHConsole) appendKeyboardInteractiveAuthMethod(autoMethods *[]ssh.AuthMethod) {
+	if self.password != "" {
+		*autoMethods = append(*autoMethods, ssh.KeyboardInteractive(func(user, instruction string, questions []string, echos []bool) (answers []string, err error) { return answers, nil } ))
+	}
+}
 
 func (self *SSHConsole) keepSSHAlive(cl *ssh.Client, conn net.Conn) error {
 	const keepAliveInterval = time.Minute
@@ -137,6 +142,7 @@ func (self *SSHConsole) connectToHost() error {
 	autoMethods := make([]ssh.AuthMethod, 0)
 	self.appendPrivateKeyAuthMethod(&autoMethods)
 	self.appendPasswordAuthMethod(&autoMethods)
+	self.appendKeyboardInteractiveAuthMethod(&autoMethods)
 	sshConfig := &ssh.ClientConfig{
 		User:            self.user,
 		Auth:            autoMethods,


### PR DESCRIPTION
ssh auth with only Password auth doesn't work for some server's platforms. 
For example on Dell R520/620/720 where you can't use ssh key auth because of license.